### PR TITLE
Allow redefinition of the uvicorn run command to use HTTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN pip install --no-cache-dir git+https://github.com/smallcloudai/refact-self-h
 
 ENV SERVER_WORKDIR=/workdir
 ENV SERVER_PORT=8008
+ENV SERVER_SCHEME=https
 EXPOSE $SERVER_PORT
 
 CMD ["python", "-m", "refact_self_hosting.watchdog", "--workdir", "/workdir"]

--- a/refact_self_hosting/server.py
+++ b/refact_self_hosting/server.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
 
     parser = ArgumentParser()
     parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--scheme", type=str, default="https")
     parser.add_argument("--port", type=int, default=8008)
     parser.add_argument("--cpu", action="store_true")
     parser.add_argument("--workdir", type=Path)
@@ -45,8 +46,13 @@ if __name__ == "__main__":
     async def startup_event():
         asyncio.create_task(inference.model_setup_loop_forever(model_name=args.model, workdir=args.workdir))
 
-    key_filename, cert_filename = gen_certificate(args.workdir)
-    uvicorn.run(
-        app, host=args.host, port=args.port,
-        loop="uvloop", timeout_keep_alive=600,
-        ssl_keyfile=key_filename, ssl_certfile=cert_filename)
+    if args.scheme == "https":
+        key_filename, cert_filename = gen_certificate(args.workdir)
+        uvicorn.run(
+            app, host=args.host, port=args.port,
+            loop="uvloop", timeout_keep_alive=600,
+            ssl_keyfile=key_filename, ssl_certfile=cert_filename)
+    else:
+        uvicorn.run(
+            app, host=args.host, port=args.port,
+            loop="uvloop", timeout_keep_alive=600)

--- a/refact_self_hosting/watchdog.py
+++ b/refact_self_hosting/watchdog.py
@@ -14,10 +14,12 @@ from typing import Optional
 class Watchdog:
 
     def __init__(self,
+                 scheme: str,
                  port: int,
                  workdir: str,
                  model: str,
                  failed_upgrade_quit: bool = False):
+        self._scheme = scheme
         self._port = port
         self._workdir = workdir
         self._model = model
@@ -33,6 +35,7 @@ class Watchdog:
                 sys.executable,
                 "-m",
                 "refact_self_hosting.server",
+                f"--scheme={self._scheme}",
                 f"--port={self._port}",
                 f"--workdir={self._workdir}",
                 f"--model={self._model}",
@@ -70,6 +73,10 @@ class Watchdog:
 
 if __name__ == "__main__":
     workdir = str(os.environ.get("SERVER_WORKDIR"))
+    scheme = os.environ.get("SERVER_SCHEME")
+    if scheme not in ("http", "https"):
+        print("SERVER_SCHEME must be http or https")
+        exit(1)
     port = int(os.environ.get("SERVER_PORT"))
     model = os.environ.get("SERVER_MODEL")
 
@@ -84,6 +91,7 @@ if __name__ == "__main__":
                         datefmt='%Y-%m-%d %H:%M:%S')
 
     watchdog = Watchdog(
+        scheme=scheme,
         port=port,
         workdir=workdir,
         model=model,


### PR DESCRIPTION
My primary use case for this is to run the self-hosted instance behind a reverse proxy like Traefik to put a Let's Encrypt HTTPS cert on it, rather than using a self-signed cert.