### PR TITLE
 Add support for Azure, OpenAI, Llama2, Palm, Cohere, Replicate Models - using litellm

### DIFF
--- a/refact_scratchpads_no_gpu/gpt_toolbox/gpt_chat_spad.py
+++ b/refact_scratchpads_no_gpu/gpt_toolbox/gpt_chat_spad.py
@@ -6,6 +6,7 @@ from typing import List, Tuple, Dict, Union, Iterator
 from refact_scratchpads_no_gpu.async_scratchpad import ascratch
 
 import openai
+from litellm import acompletion
 import tiktoken
 
 
@@ -91,7 +92,7 @@ class GptChat(ascratch.AsyncScratchpad):
         return gpt_prices(self._model_name)
 
     async def completion(self) -> Iterator[Dict[str, str]]:
-        gen = await openai.ChatCompletion.acreate(
+        gen = await acompletion(
             model=self._model_name,
             messages=self._messages,
             max_tokens=self.max_tokens,

--- a/refact_scratchpads_no_gpu/gpt_toolbox/gpt_toolbox_spad.py
+++ b/refact_scratchpads_no_gpu/gpt_toolbox/gpt_toolbox_spad.py
@@ -7,6 +7,7 @@ import json
 from typing import List, Union, Callable, Dict, Iterator, Tuple
 
 import openai
+from litellm import acompletion
 import tiktoken
 
 from refact_scratchpads_no_gpu.gpt_toolbox.scratchpad_utils import full_line_selection
@@ -119,7 +120,7 @@ class ScratchpadToolboxGPT(ascratch.AsyncScratchpad):
             return {self.cursor_file: modified}
 
         try:
-            gen = await openai.ChatCompletion.acreate(
+            gen = await acompletion(
                 model=self.model_name,
                 messages=self.messages,
                 max_tokens=self.max_tokens,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ all_refact_packages = {
         requires=["termcolor", "torch"],
         requires_packages=["refact_encoding", "code_contrast", "refact_scratchpads_no_gpu"]),
     "refact_scratchpads_no_gpu": PyPackage(
-        requires=["termcolor", "aiohttp", "tiktoken", "openai", "ujson"]),
+        requires=["termcolor", "aiohttp", "tiktoken", "openai", "ujson", "litellm"]),
     "refact_data_pipeline": PyPackage(
         requires=["numpy", "tokenizers", "torch", "requests", "cloudpickle",
                   "tqdm", "dataclasses_json", "termcolor", 'more_itertools',


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```