### PR TITLE
Pin `tokenizers`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ all_refact_packages = {
         requires=["dataclasses", "dataclasses_json"],
         data=["refact_toolbox_db/htmls/*.html"]),
     "refact_encoding": PyPackage(
-        requires=["tiktoken", "tokenizers", "sentencepiece", "termcolor"],
+        requires=["tiktoken", "tokenizers==0.13.3", "sentencepiece", "termcolor"],
         data=["*.json"]),
     "refact_models": PyPackage(
         requires=["torch", "blobfile", "cloudpickle", "huggingface_hub",
@@ -35,7 +35,7 @@ all_refact_packages = {
     "refact_scratchpads_no_gpu": PyPackage(
         requires=["termcolor", "aiohttp", "tiktoken", "openai", "ujson", "setproctitle"]),
     "refact_data_pipeline": PyPackage(
-        requires=["numpy", "tokenizers", "torch", "requests", "cloudpickle",
+        requires=["numpy", "tokenizers==0.13.3", "torch", "requests", "cloudpickle",
                   "tqdm", "dataclasses_json", "termcolor", 'more_itertools',
                   "cdifflib", "ujson", "zstandard", "scipy", "deepspeed==0.9.2",
                   "peft", "einops", "mpi4py", "matplotlib", "transformers",


### PR DESCRIPTION
I don't know if this is needed, but it prevents errors with transformers.

See https://github.com/huggingface/transformers/blob/5af2c6269672cda01c24ad48fab13f14a3ffb746/setup.py#L175 and https://pypi.org/project/tokenizers/0.13.3/#history

[0.13.4rc3](https://pypi.org/project/tokenizers/0.13.4rc3/) should work as well.

Is it an independent dependency because of `refact_encoding`?