### PR TITLE
Consistency for active-tab & history

### DIFF
--- a/self_hosting_machinery/webgui/selfhost_plugins.py
+++ b/self_hosting_machinery/webgui/selfhost_plugins.py
@@ -7,7 +7,7 @@ class PluginsRouter(APIRouter):
     def __init__(self):
         super().__init__()
         self.plugins = [
-            {"label": "Model Hosting", "tab": "model-hosting", "active": True},
+            {"label": "Model Hosting", "tab": "model-hosting"},
             {"label": "Sources", "tab": "upload"},
             {"label": "Finetune", "tab": "finetune"},
             {"label": "Server Logs", "tab": "server-logs"},

--- a/self_hosting_machinery/webgui/static/index.html
+++ b/self_hosting_machinery/webgui/static/index.html
@@ -18,7 +18,7 @@
 <body>
   <nav class="navbar navbar-expand-lg">
     <div class="container">
-      <a class="navbar-brand" href="/">
+      <a class="navbar-brand">
         <svg width="121" height="33" viewBox="0 0 121 33" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M0 32.732V0.756836H9.74697V4.77426H5.08967V28.7019H9.74697V32.732H0Z" fill="#FF3636"></path>
           <path
@@ -81,7 +81,7 @@
 
   <div class="container mt-5">
     <div class="main-tab-content">
-      <div class="main-tab-pane main-active" id="model-hosting">
+      <div class="main-tab-pane" id="model-hosting">
       </div>
       <div class="main-tab-pane" id="upload">
       </div>

--- a/self_hosting_machinery/webgui/static/index.js
+++ b/self_hosting_machinery/webgui/static/index.js
@@ -1,7 +1,7 @@
-
+const default_tab = 'model-hosting'
+let first_page_load = true;
 const req = await fetch('list-plugins');
 const plugins = await req.json();
-
 // show navigation bar immediately, import later
 plugins_to_top_nav_bar(plugins);
 
@@ -18,6 +18,13 @@ for (const p of inits_working) {
     await p;
 }
 
+const navbar = document.querySelector('.navbar-brand')
+navbar.addEventListener('click', () => {
+    first_page_load = true;
+    localStorage.setItem('active_tab_storage', default_tab);
+    start_tab_timer();
+})
+
 function active_tab_switched() {
     const active_tab = document.querySelector('.main-tab-pane.main-active');
     for (const plugin of plugins) {
@@ -27,6 +34,7 @@ function active_tab_switched() {
     }
     for (const plugin of plugins) {
         if (active_tab.id === plugin.tab) {
+            localStorage.setItem('active_tab_storage', plugin.tab);
             plugin.mod.tab_switched_here();
             break;
         }
@@ -45,7 +53,42 @@ function every_couple_of_seconds() {
 
 let refresh_interval = null;
 
+
+function on_first_page_load() {
+    if (!first_page_load) {
+        return;
+    }
+    if (first_page_load) {
+        let done = false;
+        const active_tab_storage = localStorage.getItem('active_tab_storage') || default_tab;
+        document.querySelectorAll('.main-tab-pane').forEach(tab => {
+            tab.classList.remove('main-active');
+            if (tab.getAttribute('id') === active_tab_storage) {
+                tab.classList.add('main-active');
+                done = true;
+            }
+        });
+        if (!done) {
+            document.getElementById(default_tab).classList.add('main-active');
+        }
+        done = false;
+        document.querySelectorAll('.nav-link.main-tab-button').forEach(btn => {
+            btn.classList.remove('main-active');
+            if (btn.getAttribute('data-tab') === active_tab_storage) {
+                btn.classList.add('main-active');
+                done = true;
+            }
+        });
+        if (!done) {
+            document.querySelector(`button[data-tab=${default_tab}]`).classList.add('main-active');
+        }
+        first_page_load = false;
+    }
+}
+
+
 function start_tab_timer() {
+    on_first_page_load();
     active_tab_switched();
     if (refresh_interval) {
         clearInterval(refresh_interval);

--- a/self_hosting_machinery/webgui/static/index.js
+++ b/self_hosting_machinery/webgui/static/index.js
@@ -2,6 +2,8 @@ const default_tab = 'model-hosting'
 let first_page_load = true;
 const req = await fetch('list-plugins');
 const plugins = await req.json();
+let history_state = [];
+let create_h_state = true;
 // show navigation bar immediately, import later
 plugins_to_top_nav_bar(plugins);
 
@@ -26,13 +28,18 @@ navbar.addEventListener('click', () => {
 })
 
 
-window.addEventListener('popstate', (event) =>{
+window.addEventListener('popstate', () => {
+    if (!history_state.length) {
+        return;
+    }
+    const page = history_state.at(-2);
+    history_state.pop();
     first_page_load = true;
-    localStorage.setItem('active_tab_storage', event.state.page);
-    start_tab_timer();
+    localStorage.setItem('active_tab_storage', page);
     setTimeout(() => {
-        active_tab_switched();
-    }, 500);
+        start_tab_timer();
+    }, 100);
+    create_h_state = false;
 });
 
 function active_tab_switched() {
@@ -45,7 +52,14 @@ function active_tab_switched() {
     for (const plugin of plugins) {
         if (active_tab.id === plugin.tab) {
             localStorage.setItem('active_tab_storage', plugin.tab);
-            history.pushState({'page': plugin.tab}, '', '')
+            history.pushState({'page': plugin.tab}, '', '');
+            if (create_h_state) {
+                history_state.push(plugin.tab);
+            }
+            if (history_state.length > 20) {
+                history_state.shift();
+            }
+            create_h_state = true;
             plugin.mod.tab_switched_here();
             break;
         }

--- a/self_hosting_machinery/webgui/static/index.js
+++ b/self_hosting_machinery/webgui/static/index.js
@@ -25,6 +25,16 @@ navbar.addEventListener('click', () => {
     start_tab_timer();
 })
 
+
+window.addEventListener('popstate', (event) =>{
+    first_page_load = true;
+    localStorage.setItem('active_tab_storage', event.state.page);
+    start_tab_timer();
+    setTimeout(() => {
+        active_tab_switched();
+    }, 500);
+});
+
 function active_tab_switched() {
     const active_tab = document.querySelector('.main-tab-pane.main-active');
     for (const plugin of plugins) {
@@ -35,6 +45,7 @@ function active_tab_switched() {
     for (const plugin of plugins) {
         if (active_tab.id === plugin.tab) {
             localStorage.setItem('active_tab_storage', plugin.tab);
+            history.pushState({'page': plugin.tab}, '', '')
             plugin.mod.tab_switched_here();
             break;
         }

--- a/self_hosting_machinery/webgui/static/index.js
+++ b/self_hosting_machinery/webgui/static/index.js
@@ -32,6 +32,12 @@ window.addEventListener('popstate', () => {
     if (!history_state.length) {
         return;
     }
+    // hide all active modals
+    document.querySelectorAll('.modal').forEach(modal => {
+      let currentModal = bootstrap.Modal.getInstance(modal)
+      if (currentModal) currentModal.hide()
+    })
+
     const page = history_state.at(-2);
     history_state.pop();
     first_page_load = true;


### PR DESCRIPTION
Changelist:
* when reloading the page, instead of being redirected to the default model-hosting pane you, will be kept on pane you were at before reloading
* navbar-brand redirects to the default pane: "model-hosting" instead of reloading
* history for visited panes that enables you to be redirected to prev pane on "go back" action in browser