### PR TITLE
storing stats in RAM is Optional && no stats reload by default

### DIFF
--- a/self_hosting_machinery/dashboard_service/server.py
+++ b/self_hosting_machinery/dashboard_service/server.py
@@ -11,23 +11,23 @@ from self_hosting_machinery.webgui.selfhost_database import RefactDatabase
 from self_hosting_machinery.webgui.selfhost_database import StatisticsService
 from self_hosting_machinery.dashboard_service.dashboards.dash_prime import DashboardPrimeRouter
 from self_hosting_machinery.dashboard_service.dashboards.dash_teams import DashboardTeamsRouter
-from self_hosting_machinery.dashboard_service.utils import retrieve_all_data_tables, NoDataInDatabase
+from self_hosting_machinery.dashboard_service.utils import StatsDataTablesCache
 
 
-def create_app_with_routers(data_tables):
+def create_app_with_routers(data_tables: StatsDataTablesCache):
     app = FastAPI()
     app.include_router(
         DashboardPrimeRouter(
             prefix="/dash-prime",
             tags=["dashboards"],
-            data_tables=data_tables
+            data_tables=data_tables,
         )
     )
     app.include_router(
         DashboardTeamsRouter(
             prefix="/dash-teams",
             tags=["dashboards"],
-            data_tables=data_tables
+            data_tables=data_tables,
         )
     )
     return app
@@ -41,11 +41,7 @@ def main(args: argparse.Namespace):
     stats_service = StatisticsService(database)
     stats_service.init_models()
 
-    # data is fetched once on a start, but service is being restarted every 1h by watchdog
-    try:
-        data_tables = retrieve_all_data_tables(stats_service)
-    except NoDataInDatabase:
-        data_tables = None
+    data_tables = StatsDataTablesCache(stats_service.session, clear_cache_when_done=True)
 
     app = create_app_with_routers(data_tables)
     uvicorn.run(app, host=args.host, port=args.port, loop="uvloop", timeout_keep_alive=600)

--- a/self_hosting_machinery/dashboard_service/utils.py
+++ b/self_hosting_machinery/dashboard_service/utils.py
@@ -181,9 +181,6 @@ def retrieve_all_data_tables(session) -> StatsDataTables:
     robot_human_df = robot_human_df_from_ts(session, timestamp_start_of_year)
     # comp_counters_df = comp_counters_df_from_ts(stats_service, timestamp_start_of_year)
 
-    if robot_human_df.empty:
-        raise NoDataInDatabase("No data in database!")
-
     # network_df['dt_end'] = pd.to_datetime(network_df['ts_end'], unit='s')
     robot_human_df['dt_end'] = pd.to_datetime(robot_human_df['ts_end'], unit='s')
     # comp_counters_df['dt_end'] = pd.to_datetime(comp_counters_df['ts_end'], unit='s')

--- a/self_hosting_machinery/watchdog/watchdog.d/dashboard.cfg
+++ b/self_hosting_machinery/watchdog/watchdog.d/dashboard.cfg
@@ -1,6 +1,5 @@
 {
     "policy": ["always_on"],
     "command_line": ["python", "-m", "self_hosting_machinery.dashboard_service.server"],
-    "restart_every": 3600,
     "gpus": []
 }


### PR DESCRIPTION
Changelist:
* records are no longer fetching on dashboard_service.server's start
* by default, records are fetching on request and erasing right after request was processed
* restart of dashboard_service.server is no longer required
