### PR TITLE
feat(command completion): add lsp proxys for command completion

### DIFF
--- a/refact_webgui/webgui/selfhost_lsp_proxy.py
+++ b/refact_webgui/webgui/selfhost_lsp_proxy.py
@@ -34,6 +34,8 @@ class LspProxy(APIRouter):
         super().__init__(*args, **kwargs)
         super().add_route("/lsp/v1/caps", self._reverse_proxy, methods=["GET"])
         super().add_route("/lsp/v1/chat", self._reverse_proxy_chat, methods=["POST"])
+        super().add_route("/lsp/v1/at-command-completion", self._reverse_proxy, methods=["POST"])
+        super().add_route("/lsp/v1/at-command-preview", self._reverse_proxy, methods=["POST"])
         lsp_address = get_lsp_url()
         self._session = session
         self._client = httpx.AsyncClient(base_url=lsp_address)


### PR DESCRIPTION
### TBD
Should we add a bearer token check the the endpoint like we do with chat?

### To run 
add the following to the `lsp.cfg` file
```
{
    ...
    "interrupt_when_file_appears": "%FLAG_RESTART_LSP%",
    "command_line": [
        ...
        "--vecdb",
        "-f", "/home/user/.refact/tmp/unpacked-files/train_set.jsonl"
    ],
}
```
