### PR TITLE
Fix file leakage vulnerability

### DIFF
--- a/refact_webgui/webgui/selfhost_static.py
+++ b/refact_webgui/webgui/selfhost_static.py
@@ -38,7 +38,7 @@ class StaticRouter(APIRouter):
             raise HTTPException(404, "Path \"%s\" not found" % file_path)
 
         for spath in self.static_folders:
-            fn = os.path.join(spath, file_path)
+            fn = spath + "/" + file_path
             if os.path.exists(fn):
                 if fn.endswith(".cjs"):
                     return FileResponse(fn, media_type="text/javascript")


### PR DESCRIPTION
Currently, there is a file leakage vulnerability on the server. For instance, when I access http://127.0.0.1:8008//etc/passwd, I can view the contents of the /etc/passwd file. The root cause lies in the execution of os.path.join(path1, path2), where if path2 is an absolute path, path1 will be ignored.