### PR TITLE
Codellama deprecation

### DIFF
--- a/refact_known_models/huggingface.py
+++ b/refact_known_models/huggingface.py
@@ -96,7 +96,8 @@ huggingface_mini_db = {
         "model_class_kwargs": {},
         "required_memory_mb": 14000,
         "T": 2048,
-        "filter_caps": ["completion", "finetune"],
+        "filter_caps": ["completion"],
+        "deprecated": True,
     },
     "wizardlm/30b": {
         "backend": "transformers",


### PR DESCRIPTION
We will not support codellama/7b model later:
* there are a lot of problems with codellama/7b implementation: bad FIM caps (possibly because of prompting), OOMs and errors while training process
* codellama/7b could be replaced with starcoder2 due to it's better performance