### PR TITLE
GPU OOM problem when finetuning fix

### DIFF
--- a/refact_utils/finetune/train_defaults.py
+++ b/refact_utils/finetune/train_defaults.py
@@ -1,6 +1,6 @@
 finetune_train_defaults = {
     "autoselect_test_files_num": 3,
-    "model_ctx_size": 0,
+    "model_ctx_size": 2048,
     "filter_loss_threshold": 3.0,
     "trainable_embeddings": False,
     "low_gpu_mem_mode": True,

--- a/refact_webgui/webgui/static/tab-finetune.js
+++ b/refact_webgui/webgui/static/tab-finetune.js
@@ -128,8 +128,8 @@ const finetune_settings_inputs = [
         "name": "model_ctx_size",
         "label": "Context Size",
         "type": "select",
-        "values": ['auto', 128, 256, 512, 1024, 2048, 4096],
-        "info": "Min 0, Max 4096",
+        "values": ['auto', 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768],
+        "info": "Min 0, Max 32768",
         "hint": "",
     },
 ]

--- a/refact_webgui/webgui/tab_finetune.py
+++ b/refact_webgui/webgui/tab_finetune.py
@@ -68,7 +68,7 @@ class TabFinetuneTrainingSetup(BaseModel):
     lora_r: Optional[int] = Query(default=16, ge=4, le=64)
     lora_alpha: Optional[int] = Query(default=32, ge=4, le=128)
     lora_dropout: Optional[float] = Query(default=0.01, ge=0.0, le=0.5)
-    model_ctx_size: Optional[int] = Query(default=0, ge=0, le=4096)  # in case of 0 we use default model's ctx_size
+    model_ctx_size: Optional[int] = Query(default=2048, ge=0, le=4096)  # in case of 0 we use default model's ctx_size
     filter_loss_threshold: Optional[float] = Query(default=3.0, ge=1.0, le=10.0)
     gpus: List[int] = Field(..., example=[0])
 


### PR DESCRIPTION
- make model_ctx_size default = 2048
- introducing more choices to the model_ctx_size at the finetuning stage