### PR TITLE
fix(chat)): opening an old chat from history without the newer `suggested_chat` property.

### DIFF
--- a/refact-agent/gui/src/components/ChatHistory/ChatHistory.tsx
+++ b/refact-agent/gui/src/components/ChatHistory/ChatHistory.tsx
@@ -3,14 +3,14 @@ import { Flex, Box } from "@radix-ui/themes";
 import { ScrollArea } from "../ScrollArea";
 import { HistoryItem } from "./HistoryItem";
 import {
+  ChatHistoryItem,
   getHistory,
   type HistoryState,
 } from "../../features/History/historySlice";
-import type { ChatThread } from "../../features/Chat/Thread/types";
 
 export type ChatHistoryProps = {
   history: HistoryState;
-  onHistoryItemClick: (id: ChatThread) => void;
+  onHistoryItemClick: (id: ChatHistoryItem) => void;
   onDeleteHistoryItem: (id: string) => void;
   onOpenChatInTab?: (id: string) => void;
   currentChatId?: string;

--- a/refact-agent/gui/src/components/ChatRawJSON/ChatRawJSON.tsx
+++ b/refact-agent/gui/src/components/ChatRawJSON/ChatRawJSON.tsx
@@ -1,10 +1,10 @@
 import { Box, Button, Flex, Heading } from "@radix-ui/themes";
 import { ScrollArea } from "../ScrollArea";
-import { RootState } from "../../app/store";
 import { MarkdownCodeBlock } from "../Markdown/CodeBlock";
+import { ChatHistoryItem } from "../../events";
 
 type ChatRawJSONProps = {
-  thread: RootState["chat"]["thread"];
+  thread: ChatHistoryItem;
   copyHandler: () => void;
 };
 

--- a/refact-agent/gui/src/components/Sidebar/Sidebar.tsx
+++ b/refact-agent/gui/src/components/Sidebar/Sidebar.tsx
@@ -3,9 +3,12 @@ import { Box, Flex } from "@radix-ui/themes";
 import { ChatHistory, type ChatHistoryProps } from "../ChatHistory";
 import { Spinner } from "@radix-ui/themes";
 import { useAppSelector, useAppDispatch } from "../../hooks";
-import { deleteChatById } from "../../features/History/historySlice";
+import {
+  ChatHistoryItem,
+  deleteChatById,
+} from "../../features/History/historySlice";
 import { push } from "../../features/Pages/pagesSlice";
-import { restoreChat, type ChatThread } from "../../features/Chat/Thread";
+import { restoreChat } from "../../features/Chat/Thread";
 import { FeatureMenu } from "../../features/Config/FeatureMenu";
 
 export type SidebarProps = {
@@ -35,7 +38,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
   );
 
   const onHistoryItemClick = useCallback(
-    (thread: ChatThread) => {
+    (thread: ChatHistoryItem) => {
       dispatch(restoreChat(thread));
       dispatch(push({ name: "chat" }));
     },

--- a/refact-agent/gui/src/features/Chat/Thread/actions.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/actions.ts
@@ -33,6 +33,7 @@ import {
 import { ToolCommand } from "../../../services/refact/tools";
 import { scanFoDuplicatesWith, takeFromEndWhile } from "../../../utils";
 import { debugApp } from "../../../debugConfig";
+import { ChatHistoryItem } from "../../History/historySlice";
 
 export const newChatAction = createAction("chatThread/new");
 
@@ -94,7 +95,9 @@ export const removeChatFromCache = createAction<PayloadWithId>(
   "chatThread/removeChatFromCache",
 );
 
-export const restoreChat = createAction<ChatThread>("chatThread/restoreChat");
+export const restoreChat = createAction<ChatHistoryItem>(
+  "chatThread/restoreChat",
+);
 
 export const clearChatError = createAction<PayloadWithId>(
   "chatThread/clearError",

--- a/refact-agent/gui/src/features/Chat/Thread/reducer.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/reducer.ts
@@ -269,7 +269,10 @@ export const chatReducer = createReducer(initialState, (builder) => {
       state.streaming = false;
     }
     state.prevent_send = true;
-    state.thread = mostUptoDateThread;
+    state.thread = {
+      new_chat_suggested: { wasSuggested: false },
+      ...mostUptoDateThread,
+    };
     state.thread.tool_use = state.thread.tool_use ?? state.tool_use;
   });
 

--- a/refact-agent/gui/src/features/History/historySlice.ts
+++ b/refact-agent/gui/src/features/History/historySlice.ts
@@ -12,6 +12,7 @@ import {
   removeChatFromCache,
   restoreChat,
   setChatMode,
+  SuggestedChat,
 } from "../Chat/Thread";
 import {
   isAssistantMessage,
@@ -20,11 +21,12 @@ import {
 } from "../../services/refact";
 import { AppDispatch, RootState } from "../../app/store";
 
-export type ChatHistoryItem = ChatThread & {
+export type ChatHistoryItem = Omit<ChatThread, "new_chat_suggested"> & {
   createdAt: string;
   updatedAt: string;
   title: string;
   isTitleGenerated?: boolean;
+  new_chat_suggested?: SuggestedChat;
 };
 
 export type HistoryMeta = Pick<


### PR DESCRIPTION
Issue: https://refact.fibery.io/Software_Development/Sprint-2025-02-17-500#Task/Chat-fails-when-tried-to-open-old-chat-885

History items may or may not have `new_chat_suggested` on them.

To test.

build,
link to vscode
open an old chat.