### PR TITLE
Fix textdoc file reading

### DIFF
--- a/refact-agent/engine/src/tools/file_edit/tool_create_textdoc.rs
+++ b/refact-agent/engine/src/tools/file_edit/tool_create_textdoc.rs
@@ -68,7 +68,7 @@ pub async fn tool_create_text_doc_exec(
 ) -> Result<(String, String, Vec<DiffChunk>), String> {
     let args = parse_args(args)?;
     await_ast_indexing(gcx.clone()).await?;
-    let (before_text, after_text) = write_file(&args.path, &args.content, dry)?;
+    let (before_text, after_text) = write_file(gcx.clone(), &args.path, &args.content, dry).await?;
     sync_documents_ast(gcx.clone(), &args.path).await?;
     let diff_chunks = convert_edit_to_diffchunks(args.path.clone(), &before_text, &after_text)?;
     Ok((before_text, after_text, diff_chunks))

--- a/refact-agent/engine/src/tools/file_edit/tool_replace_textdoc.rs
+++ b/refact-agent/engine/src/tools/file_edit/tool_replace_textdoc.rs
@@ -73,7 +73,7 @@ pub async fn tool_replace_text_doc_exec(
 ) -> Result<(String, String, Vec<DiffChunk>), String> {
     let args = parse_args(args)?;
     await_ast_indexing(gcx.clone()).await?;
-    let (before_text, after_text) = write_file(&args.path, &args.replacement, dry)?;
+    let (before_text, after_text) = write_file(gcx.clone(), &args.path, &args.replacement, dry).await?;
     sync_documents_ast(gcx.clone(), &args.path).await?;
     let diff_chunks = convert_edit_to_diffchunks(args.path.clone(), &before_text, &after_text)?;
     Ok((before_text, after_text, diff_chunks))

--- a/refact-agent/engine/src/tools/file_edit/tool_update_textdoc.rs
+++ b/refact-agent/engine/src/tools/file_edit/tool_update_textdoc.rs
@@ -75,7 +75,7 @@ pub async fn tool_update_text_doc_exec(
 ) -> Result<(String, String, Vec<DiffChunk>), String> {
     let args = parse_args(args)?;
     await_ast_indexing(gcx.clone()).await?;
-    let (before_text, after_text) = str_replace(&args.path, &args.old_str, &args.replacement, args.multiple, dry)?;
+    let (before_text, after_text) = str_replace(gcx.clone(), &args.path, &args.old_str, &args.replacement, args.multiple, dry).await?;
     sync_documents_ast(gcx.clone(), &args.path).await?;
     let diff_chunks = convert_edit_to_diffchunks(args.path.clone(), &before_text, &after_text)?;
     Ok((before_text, after_text, diff_chunks))

--- a/refact-agent/engine/src/tools/file_edit/tool_update_textdoc_regex.rs
+++ b/refact-agent/engine/src/tools/file_edit/tool_update_textdoc_regex.rs
@@ -83,7 +83,7 @@ pub async fn tool_update_text_doc_regex_exec(
 ) -> Result<(String, String, Vec<DiffChunk>), String> {
     let args = parse_args(args)?;
     await_ast_indexing(gcx.clone()).await?;
-    let (before_text, after_text) = str_replace_regex(&args.path, &args.pattern, &args.replacement, args.multiple, dry)?;
+    let (before_text, after_text) = str_replace_regex(gcx.clone(), &args.path, &args.pattern, &args.replacement, args.multiple, dry).await?;
     sync_documents_ast(gcx.clone(), &args.path).await?;
     let diff_chunks = convert_edit_to_diffchunks(args.path.clone(), &before_text, &after_text)?;
     Ok((before_text, after_text, diff_chunks))


### PR DESCRIPTION
Fix textdoc tools to use get_file_text_from_memory_or_disk instead of read_to_string