### PR TITLE
fix(tool confirmation): chat should continue if the user denies the tool use.

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/ToolConfirmation.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ToolConfirmation.tsx
@@ -88,10 +88,6 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     confirmToolUsage();
   };
 
-  const handleReject = useCallback(() => {
-    rejectToolUsage(toolCallIds);
-  }, [rejectToolUsage, toolCallIds]);
-
   const message = getConfirmationMessage(
     commands,
     rules,
@@ -105,7 +101,7 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     return (
       <PatchConfirmation
         handleAllowForThisChat={handleAllowForThisChat}
-        rejectToolUsage={handleReject}
+        rejectToolUsage={rejectToolUsage}
         confirmToolUsage={confirmToolUsage}
       />
     );
@@ -171,7 +167,7 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
               color="red"
               variant="surface"
               size="1"
-              onClick={handleReject}
+              onClick={rejectToolUsage}
             >
               Stop
             </Button>

--- a/refact-agent/gui/src/components/ChatForm/ToolConfirmation.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ToolConfirmation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import {
   PATCH_LIKE_FUNCTIONS,
   useAppDispatch,

--- a/refact-agent/gui/src/hooks/useSendChatRequest.ts
+++ b/refact-agent/gui/src/hooks/useSendChatRequest.ts
@@ -50,11 +50,9 @@ import {
   setChatMode,
   setIsWaitingForResponse,
   setLastUserMessageId,
-  upsertToolCall,
 } from "../features/Chat";
 
 import { v4 as uuidv4 } from "uuid";
-import { upsertToolCallIntoHistory } from "../features/History/historySlice";
 
 type SubmitHandlerParams =
   | {
@@ -321,27 +319,16 @@ export const useSendChatRequest = () => {
     dispatch(setIsWaitingForResponse(false));
   }, [abort, dispatch]);
 
-  const rejectToolUsage = useCallback(
-    (toolCallIds: string[]) => {
-      abort();
-
-      toolCallIds.forEach((toolCallId) => {
-        dispatch(
-          upsertToolCallIntoHistory({ toolCallId, chatId, accepted: false }),
-        );
-        dispatch(upsertToolCall({ toolCallId, chatId, accepted: false }));
-      });
-
-      dispatch(
-        clearPauseReasonsAndHandleToolsStatus({
-          wasInteracted: true,
-          confirmationStatus: false,
-        }),
-      );
-      dispatch(setIsWaitingForResponse(false));
-    },
-    [abort, chatId, dispatch],
-  );
+  const rejectToolUsage = useCallback(() => {
+    abort();
+    dispatch(
+      clearPauseReasonsAndHandleToolsStatus({
+        wasInteracted: true,
+        confirmationStatus: false,
+      }),
+    );
+    dispatch(setIsWaitingForResponse(false));
+  }, [abort, dispatch]);
 
   const retryFromIndex = useCallback(
     (index: number, question: UserMessage["content"]) => {


### PR DESCRIPTION
What changed.

Pressing `stop` in the tool confirmation window would stop the chat.

Now: pressing stop will call the lsp to get the `stop` reason message.