### PR TITLE
some stuff

### DIFF
--- a/refact-agent/gui/src/__fixtures__/caps.ts
+++ b/refact-agent/gui/src/__fixtures__/caps.ts
@@ -340,10 +340,12 @@ export const STUB_CAPS_RESPONSE: CapsResponse = {
     "groq-llama-3.1-70b",
   ],
   code_chat_default_system_prompt: "default",
+  support_metadata: true,
   caps_version: 0,
 };
 
 export const EMPTY_CAPS_RESPONSE: CapsResponse = {
+  support_metadata: false,
   caps_version: 0,
   cloud_name: "",
   code_chat_default_model: "",

--- a/refact-agent/gui/src/app/middleware.ts
+++ b/refact-agent/gui/src/app/middleware.ts
@@ -553,8 +553,6 @@ startListening({
 startListening({
   actionCreator: setError,
   effect: (state, listenerApi) => {
-    // eslint-disable-next-line no-console
-    console.log(`[DEBUG]: setError`, state);
     const rootState = listenerApi.getState();
     if (
       state.payload.startsWith(USAGE_LIMITS_ERROR_MESSAGES[0]) ||

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -16,7 +16,6 @@ import {
   useConfig,
   useAgentUsage,
   useCapsForToolUse,
-  USAGE_LIMIT_EXHAUSTED_MESSAGE,
   useSendChatRequest,
 } from "../../hooks";
 import { ErrorCallout, Callout } from "../Callout";
@@ -83,7 +82,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const information = useAppSelector(getInformationMessage);
   const pauseReasonsWithPause = useAppSelector(getPauseReasonsWithPauseStatus);
   const [helpInfo, setHelpInfo] = React.useState<React.ReactNode | null>(null);
-  const { disableInput } = useAgentUsage();
+  const { disableInput, usageLimitExhaustedMessage } = useAgentUsage();
   const isOnline = useIsOnline();
   const { retry } = useSendChatRequest();
 
@@ -187,7 +186,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const handleSubmit = useCallback(() => {
     const trimmedValue = value.trim();
     if (disableInput) {
-      const action = setInformation(USAGE_LIMIT_EXHAUSTED_MESSAGE);
+      const action = setInformation(usageLimitExhaustedMessage);
       dispatch(action);
     } else if (!disableSend && trimmedValue.length > 0) {
       const valueIncludingChecks = addCheckboxValuesToInput(
@@ -204,8 +203,9 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     value,
     disableInput,
     disableSend,
-    dispatch,
     checkboxes,
+    usageLimitExhaustedMessage,
+    dispatch,
     setFileInteracted,
     setLineSelectionInteracted,
     onSubmit,

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -17,6 +17,7 @@ import {
   useAgentUsage,
   useCapsForToolUse,
   USAGE_LIMIT_EXHAUSTED_MESSAGE,
+  PAID_AGENT_LIST,
   useSendChatRequest,
 } from "../../hooks";
 import { ErrorCallout, Callout } from "../Callout";
@@ -71,7 +72,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const dispatch = useAppDispatch();
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
-  const { isMultimodalitySupportedForCurrentModel } = useCapsForToolUse();
+  const { isMultimodalitySupportedForCurrentModel, currentModel } = useCapsForToolUse();
   const config = useConfig();
   const toolUse = useAppSelector(selectToolUse);
   const globalError = useAppSelector(getErrorMessage);

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -17,7 +17,6 @@ import {
   useAgentUsage,
   useCapsForToolUse,
   USAGE_LIMIT_EXHAUSTED_MESSAGE,
-  PAID_AGENT_LIST,
   useSendChatRequest,
 } from "../../hooks";
 import { ErrorCallout, Callout } from "../Callout";
@@ -76,7 +75,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const dispatch = useAppDispatch();
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
-  const { isMultimodalitySupportedForCurrentModel, currentModel } = useCapsForToolUse();
+  const { isMultimodalitySupportedForCurrentModel } = useCapsForToolUse();
   const config = useConfig();
   const toolUse = useAppSelector(selectToolUse);
   const globalError = useAppSelector(getErrorMessage);

--- a/refact-agent/gui/src/features/AgentUsage/agentUsageSlice.ts
+++ b/refact-agent/gui/src/features/AgentUsage/agentUsageSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { smallCloudApi } from "../../services/smallcloud";
 
 export type AgentUsageMeta = {
   agent_usage: null | number; // null if plan is PRO or ROBOT
@@ -29,6 +30,18 @@ export const agentUsageSlice = createSlice({
       state.agent_usage = agent_usage;
       state.agent_max_usage_amount = agent_max_usage_amount;
     },
+  },
+
+  extraReducers: (builder) => {
+    builder.addMatcher(
+      smallCloudApi.endpoints.getUser.matchFulfilled,
+      (state, action) => {
+        const { refact_agent_max_request_num, refact_agent_request_available } =
+          action.payload;
+        state.agent_max_usage_amount = refact_agent_max_request_num;
+        state.agent_usage = refact_agent_request_available;
+      },
+    );
   },
 
   selectors: {

--- a/refact-agent/gui/src/hooks/useAgentUsage.ts
+++ b/refact-agent/gui/src/hooks/useAgentUsage.ts
@@ -13,9 +13,11 @@ import {
 } from "../features/Chat";
 import { useAppDispatch } from "./useAppDispatch";
 import { UNLIMITED_PRO_MODELS_LIST } from "./useCapsForToolUse";
+import { useGetCapsQuery } from "./useGetCapsQuery";
 
 export function useAgentUsage() {
   const dispatch = useAppDispatch();
+  const caps = useGetCapsQuery();
   const user = useGetUser();
   const agentUsage = useAppSelector(selectAgentUsage);
   const maxAgentUsageAmount = useAppSelector(selectMaxAgentUsageAmount);
@@ -86,11 +88,19 @@ export function useAgentUsage() {
       UNLIMITED_PRO_MODELS_LIST.includes(currentModel)
     )
       return false;
+    if (caps.data?.support_metadata === false) return false;
     if (isStreaming || isWaiting) return false;
     if (agentUsage === null) return false;
     if (agentUsage > 5) return false;
     return true;
-  }, [user.data?.inference, isStreaming, isWaiting, agentUsage, currentModel]);
+  }, [
+    user.data?.inference,
+    caps.data?.support_metadata,
+    isStreaming,
+    isWaiting,
+    agentUsage,
+    currentModel,
+  ]);
 
   const disableInput = useMemo(() => {
     return shouldShow && aboveUsageLimit;

--- a/refact-agent/gui/src/hooks/useAgentUsage.ts
+++ b/refact-agent/gui/src/hooks/useAgentUsage.ts
@@ -77,12 +77,16 @@ export function useAgentUsage() {
 
   const shouldShow = useMemo(() => {
     // TODO: maybe uncalled tools.
-    if (user?.data?.inference !== "FREE" && UNLIMITED_PRO_MODELS_LIST.includes(currentModel)) return false;
+    if (
+      user.data?.inference !== "FREE" &&
+      UNLIMITED_PRO_MODELS_LIST.includes(currentModel)
+    )
+      return false;
     if (isStreaming || isWaiting) return false;
     if (agentUsage === null) return false;
     if (agentUsage > 5) return false;
     return true;
-  }, [isStreaming, isWaiting, agentUsage, currentModel]);
+  }, [user.data?.inference, isStreaming, isWaiting, agentUsage, currentModel]);
 
   const disableInput = useMemo(() => {
     return shouldShow && aboveUsageLimit;

--- a/refact-agent/gui/src/hooks/useAgentUsage.ts
+++ b/refact-agent/gui/src/hooks/useAgentUsage.ts
@@ -14,9 +14,6 @@ import {
 import { useAppDispatch } from "./useAppDispatch";
 import { UNLIMITED_PRO_MODELS_LIST } from "./useCapsForToolUse";
 
-export const USAGE_LIMIT_EXHAUSTED_MESSAGE =
-  "You have exceeded the FREE usage limit. Wait till tomorrow to send messages again, or upgrade to PRO.";
-
 export function useAgentUsage() {
   const dispatch = useAppDispatch();
   const user = useGetUser();
@@ -25,6 +22,13 @@ export function useAgentUsage() {
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
   const currentModel = useAppSelector(selectModel);
+
+  const usageLimitExhaustedMessage = useMemo(() => {
+    const userPlan = user.data?.inference;
+    return userPlan === "FREE"
+      ? "You have exceeded the FREE usage limit. Wait till tomorrow to send messages again, or upgrade to PRO."
+      : "You have exceeded the PRO usage limit. Wait till tomorrow to send messages again, or increase limits.";
+  }, [user.data?.inference]);
 
   const aboveUsageLimit = useMemo(() => {
     if (agentUsage === null) return false;
@@ -101,5 +105,6 @@ export function useAgentUsage() {
     pollingForUser,
     disableInput,
     plan: user.data?.inference ?? "",
+    usageLimitExhaustedMessage,
   };
 }

--- a/refact-agent/gui/src/hooks/useAgentUsage.ts
+++ b/refact-agent/gui/src/hooks/useAgentUsage.ts
@@ -12,7 +12,7 @@ import {
   selectModel,
 } from "../features/Chat";
 import { useAppDispatch } from "./useAppDispatch";
-import { FREE_TIER_MODELS_LIST } from "./useCapsForToolUse";
+import { UNLIMITED_PRO_MODELS_LIST } from "./useCapsForToolUse";
 
 export const USAGE_LIMIT_EXHAUSTED_MESSAGE =
   "You have exceeded the FREE usage limit. Wait till tomorrow to send messages again, or upgrade to PRO.";
@@ -77,7 +77,7 @@ export function useAgentUsage() {
 
   const shouldShow = useMemo(() => {
     // TODO: maybe uncalled tools.
-    if (FREE_TIER_MODELS_LIST.includes(currentModel)) return false;
+    if (user?.data?.inference !== "FREE" && UNLIMITED_PRO_MODELS_LIST.includes(currentModel)) return false;
     if (isStreaming || isWaiting) return false;
     if (agentUsage === null) return false;
     if (agentUsage > 5) return false;

--- a/refact-agent/gui/src/hooks/useCapsForToolUse.ts
+++ b/refact-agent/gui/src/hooks/useCapsForToolUse.ts
@@ -6,9 +6,9 @@ import {
 import {
   useAppSelector,
   useGetCapsQuery,
-  useAgentUsage,
+  // useAgentUsage,
   useAppDispatch,
-  useGetUser,
+  // useGetUser,
 } from ".";
 
 import {
@@ -29,9 +29,7 @@ export const PAID_AGENT_LIST = [
   "claude-3-7-sonnet",
 ];
 
-const THINKING_MODELS_LIST = [
-  "o3-mini"
-];
+const THINKING_MODELS_LIST = ["o3-mini"];
 
 // TODO: hard coded for now. Unlimited usage models
 export const UNLIMITED_PRO_MODELS_LIST = ["gpt-4o-mini"];
@@ -41,8 +39,8 @@ export function useCapsForToolUse() {
   const caps = useGetCapsQuery();
   const toolUse = useAppSelector(selectThreadToolUse);
   const chatId = useAppSelector(selectChatId);
-  const usage = useAgentUsage();
-  const user = useGetUser();
+  // const usage = useAgentUsage();
+  // const user = useGetUser();
   const dispatch = useAppDispatch();
 
   const defaultCap = caps.data?.code_chat_default_model ?? "";
@@ -99,17 +97,36 @@ export function useCapsForToolUse() {
   }, [caps.data?.code_chat_models, toolUse]);
 
   const usableModelsForPlan = useMemo(() => {
-    return usableModels;
-  }, [user.data?.inference, usableModels, usage.aboveUsageLimit, toolUse]);
+    // TODO: keep filtering logic for the future BYOK + Cloud (to show different providers)
+    // if (user.data?.inference !== "FREE") return usableModels;
+    // if (!usage.aboveUsageLimit && toolUse === "agent") return usableModels;
+    return usableModels.map((model) => {
+      // if (!PAID_AGENT_LIST.includes(model)) return model;
+
+      return {
+        value: model,
+        disabled: false,
+        textValue:
+          // toolUse !== "agent" ? `${model} (Available in agent)` : undefined,
+          model,
+      };
+    });
+    // return usableModels;
+  }, [
+    // user.data?.inference,
+    usableModels,
+    // toolUse,
+    // usage.aboveUsageLimit,
+  ]);
 
   useEffect(() => {
     if (
       usableModelsForPlan.length > 0 &&
-      usableModelsForPlan.some((elem) => typeof elem === "string") &&
-      !usableModelsForPlan.includes(currentModel)
+      usableModelsForPlan.some((elem) => elem.textValue.includes(currentModel))
+      // !usableModelsForPlan.includes(currentModel)
     ) {
-      const models: string[] = usableModelsForPlan.filter(
-        (elem): elem is string => typeof elem === "string",
+      const models: string[] = usableModelsForPlan.map(
+        (elem) => elem.textValue,
       );
       const toChange =
         models.find((elem) => currentModel.startsWith(elem)) ??

--- a/refact-agent/gui/src/hooks/useCapsForToolUse.ts
+++ b/refact-agent/gui/src/hooks/useCapsForToolUse.ts
@@ -20,7 +20,7 @@ import {
 } from "../features/Chat";
 
 // TODO: hard coded for now.
-const PAID_AGENT_LIST = [
+export const PAID_AGENT_LIST = [
   "gpt-4o",
   "claude-3-5-sonnet",
   "grok-2-1212",
@@ -29,8 +29,12 @@ const PAID_AGENT_LIST = [
   "claude-3-7-sonnet",
 ];
 
+const THINKING_MODELS_LIST = [
+  "o3-mini"
+];
+
 // TODO: hard coded for now. Unlimited usage models
-export const FREE_TIER_MODELS_LIST = ["gpt-4o-mini"];
+export const UNLIMITED_PRO_MODELS_LIST = ["gpt-4o-mini"];
 
 export function useCapsForToolUse() {
   const [wasAdjusted, setWasAdjusted] = useState(false);
@@ -81,6 +85,7 @@ export function useCapsForToolUse() {
     const models = caps.data?.code_chat_models ?? {};
     const items = Object.entries(models).reduce<string[]>(
       (acc, [key, value]) => {
+        if (THINKING_MODELS_LIST.includes(key)) return acc;
         if (toolUse === "explore" && value.supports_tools) {
           return [...acc, key];
         }
@@ -94,18 +99,7 @@ export function useCapsForToolUse() {
   }, [caps.data?.code_chat_models, toolUse]);
 
   const usableModelsForPlan = useMemo(() => {
-    if (user.data?.inference !== "FREE") return usableModels;
-    if (!usage.aboveUsageLimit && toolUse === "agent") return usableModels;
-    return usableModels.map((model) => {
-      if (!PAID_AGENT_LIST.includes(model)) return model;
-
-      return {
-        value: model,
-        disabled: true,
-        textValue:
-          toolUse !== "agent" ? `${model} (Available in agent)` : undefined,
-      };
-    });
+    return usableModels;
   }, [user.data?.inference, usableModels, usage.aboveUsageLimit, toolUse]);
 
   useEffect(() => {

--- a/refact-agent/gui/src/hooks/useCapsForToolUse.ts
+++ b/refact-agent/gui/src/hooks/useCapsForToolUse.ts
@@ -18,6 +18,7 @@ import {
   setToolUse,
   ToolUse,
 } from "../features/Chat";
+import { setInitialAgentUsage } from "../features/AgentUsage/agentUsageSlice";
 
 // TODO: hard coded for now.
 export const PAID_AGENT_LIST = [
@@ -44,6 +45,9 @@ export function useCapsForToolUse() {
   const dispatch = useAppDispatch();
 
   const defaultCap = caps.data?.code_chat_default_model ?? "";
+
+  const supportMetadata = caps.data?.support_metadata;
+
   const selectedModel = useAppSelector(getSelectedChatModel);
 
   const currentModel = selectedModel || defaultCap;
@@ -184,6 +188,17 @@ export function useCapsForToolUse() {
     modelsSupportingAgent,
     modelsSupportingTools,
   ]);
+
+  useEffect(() => {
+    if (!supportMetadata) {
+      dispatch(
+        setInitialAgentUsage({
+          agent_max_usage_amount: 40,
+          agent_usage: null,
+        }),
+      );
+    }
+  }, [dispatch, supportMetadata]);
 
   return {
     usableModels,

--- a/refact-agent/gui/src/hooks/useSmartLinks.ts
+++ b/refact-agent/gui/src/hooks/useSmartLinks.ts
@@ -9,11 +9,11 @@ import {
 import { newIntegrationChat } from "../features/Chat/Thread/actions";
 import { push } from "../features/Pages/pagesSlice";
 import { useGoToLink } from "./useGoToLink";
-import { USAGE_LIMIT_EXHAUSTED_MESSAGE, useAgentUsage } from "./useAgentUsage";
+import { useAgentUsage } from "./useAgentUsage";
 
 export function useSmartLinks() {
   const dispatch = useAppDispatch();
-  const { aboveUsageLimit } = useAgentUsage();
+  const { aboveUsageLimit, usageLimitExhaustedMessage } = useAgentUsage();
   const { handleGoTo } = useGoToLink();
   const handleSmartLink = useCallback(
     (
@@ -24,7 +24,7 @@ export function useSmartLinks() {
     ) => {
       const messages = formatMessagesForChat(sl_chat);
       if (aboveUsageLimit) {
-        const action = setInformation(USAGE_LIMIT_EXHAUSTED_MESSAGE);
+        const action = setInformation(usageLimitExhaustedMessage);
         dispatch(action);
         return;
       }
@@ -41,7 +41,7 @@ export function useSmartLinks() {
       );
       dispatch(push({ name: "chat" }));
     },
-    [dispatch, aboveUsageLimit],
+    [dispatch, aboveUsageLimit, usageLimitExhaustedMessage],
   );
 
   return {

--- a/refact-agent/gui/src/services/refact/caps.ts
+++ b/refact-agent/gui/src/services/refact/caps.ts
@@ -91,6 +91,7 @@ export type CapsResponse = {
   telemetry_basic_dest: string;
   tokenizer_path_template: string;
   tokenizer_rewrite_path: Record<string, unknown>;
+  support_metadata: boolean;
 };
 
 export function isCapsResponse(json: unknown): json is CapsResponse {


### PR DESCRIPTION
What changed:
- `agentUsageSlice` `extraReducer` logic to set agent usage data if `getUser` request was fulfilled
- fixed frequent login requests
- adjusted info messages on attempt to send message with exhausted usage limits for PRO and FREE users
- if caps return us `support_metadata` equal to `false`, then disabling agent usage completely
- gpt-4o-mini becomes unlimited only for PRO users