### PR TITLE
Add "Open <integr_name>.yaml" button for not-erroring integration form

### DIFF
--- a/refact-agent/gui/src/components/Callout/Callout.module.css
+++ b/refact-agent/gui/src/components/Callout/Callout.module.css
@@ -32,6 +32,7 @@
     transform 0.3s ease-in-out,
     visibility 0.3s ease-in-out,
     opacity 0.3s ease-in-out;
+  /* margin: 0; */
 }
 
 .callout_from_top {
@@ -39,6 +40,15 @@
   position: absolute;
   animation: rollin_from_top 0.2s ease-out;
   z-index: 1;
+}
+
+.callout_box_inner {
+  width: calc(100% - (var(--space-2) * 2));
+  left: 0;
+}
+
+.retryText {
+  display: block;
 }
 
 @keyframes rollin_from_top {

--- a/refact-agent/gui/src/components/Callout/Callout.tsx
+++ b/refact-agent/gui/src/components/Callout/Callout.tsx
@@ -93,6 +93,7 @@ export const ErrorCallout: React.FC<Omit<CalloutProps, "type">> = ({
   onClick,
   children,
   preventRetry,
+  className,
   ...props
 }) => {
   const logout = useLogout();
@@ -106,11 +107,12 @@ export const ErrorCallout: React.FC<Omit<CalloutProps, "type">> = ({
       timeout={timeout}
       itemType={props.itemType}
       preventRetry={isAuthError ?? preventRetry}
+      className={classNames(styles.callout_box_inner, className)}
       {...props}
     >
       Error: {children}
       {!isAuthError && (
-        <Text size="1" as="p">
+        <Text size="1" as="span" className={styles.retryText}>
           {preventRetry ? "Click to close" : "Click to retry"}
         </Text>
       )}

--- a/refact-agent/gui/src/components/IntegrationsView/IntegrationForm/ErrorState.tsx
+++ b/refact-agent/gui/src/components/IntegrationsView/IntegrationForm/ErrorState.tsx
@@ -3,7 +3,8 @@ import { Badge, Button, Flex, Text } from "@radix-ui/themes";
 import { FC } from "react";
 import { IntegrationDeletePopover } from "../IntegrationDeletePopover";
 import { Integration } from "../../../services/refact";
-import { useEventsBusForIDE } from "../../../hooks";
+import { useAppSelector, useEventsBusForIDE } from "../../../hooks";
+import { selectConfig } from "../../../features/Config/configSlice";
 
 type ErrorStateProps = {
   integration: Integration;
@@ -18,11 +19,13 @@ export const ErrorState: FC<ErrorStateProps> = ({
   isDeletingIntegration,
   integration,
 }) => {
+  const config = useAppSelector(selectConfig);
   const { openFile } = useEventsBusForIDE();
 
   const { integr_name } = integration;
   const { error_msg, integr_config_path, error_line } =
     integration.error_log[0];
+
   return (
     <Flex width="100%" direction="column" align="start" gap="4">
       <Text size="2" color="gray">
@@ -33,18 +36,21 @@ export const ErrorState: FC<ErrorStateProps> = ({
         <ExclamationTriangleIcon /> {error_msg}
       </Badge>
       <Flex align="center" gap="2">
-        <Button
-          variant="outline"
-          color="gray"
-          onClick={() =>
-            openFile({
-              file_name: integr_config_path,
-              line: error_line === 0 ? 1 : error_line,
-            })
-          }
-        >
-          Open {integr_name}.yaml
-        </Button>
+        {config.host !== "web" && (
+          <Button
+            variant="outline"
+            color="gray"
+            title={`Open ${integr_name}.yaml configuration file in your IDE`}
+            onClick={() =>
+              openFile({
+                file_name: integr_config_path,
+                line: error_line === 0 ? 1 : error_line,
+              })
+            }
+          >
+            Open {integr_name}.yaml
+          </Button>
+        )}
         <IntegrationDeletePopover
           integrationName={integr_name}
           integrationConfigPath={integr_config_path}

--- a/refact-agent/gui/src/components/IntegrationsView/IntegrationForm/FormSmartlinks.tsx
+++ b/refact-agent/gui/src/components/IntegrationsView/IntegrationForm/FormSmartlinks.tsx
@@ -1,7 +1,9 @@
-import { Flex, Heading } from "@radix-ui/themes";
+import { Button, Flex, Heading } from "@radix-ui/themes";
 import { SmartLink } from "../../SmartLink";
 import { FC } from "react";
 import { Integration, SmartLink as TSmartLink } from "../../../services/refact";
+import { useAppSelector, useEventsBusForIDE } from "../../../hooks";
+import { selectConfig } from "../../../features/Config/configSlice";
 
 type FormSmartlinksProps = {
   integration: Integration;
@@ -14,31 +16,58 @@ export const FormSmartlinks: FC<FormSmartlinksProps> = ({
   integration,
   availabilityValues,
 }) => {
+  const config = useAppSelector(selectConfig);
+  const { openFile } = useEventsBusForIDE();
+
+  const { integr_name, project_path, integr_config_path } = integration;
+
   if (!smartlinks?.length) return null;
 
   return (
     <Flex width="100%" direction="column" gap="1" mb="6">
-      <Flex align="center" gap="3" mt="2" wrap="wrap">
-        <Heading as="h6" size="2" weight="medium">
-          Actions:
-        </Heading>
-        {smartlinks.map((smartlink, idx) => {
-          const { integr_name, project_path, integr_config_path } = integration;
-          return (
-            <SmartLink
-              key={`smartlink-${idx}`}
-              smartlink={smartlink}
-              integrationName={integr_name}
-              integrationProject={project_path}
-              integrationPath={integr_config_path}
-              shouldBeDisabled={
-                smartlink.sl_enable_only_with_tool
-                  ? !availabilityValues.on_your_laptop
-                  : false
-              }
-            />
-          );
-        })}
+      <Flex
+        align="baseline"
+        direction={{ initial: "column-reverse", xs: "row" }}
+        justify="between"
+        gap="4"
+      >
+        <Flex align="center" gap="3" mt="2" justify="start" wrap="wrap">
+          <Heading as="h6" size="2" weight="medium">
+            Actions:
+          </Heading>
+          {smartlinks.map((smartlink, idx) => {
+            return (
+              <SmartLink
+                key={`smartlink-${idx}`}
+                smartlink={smartlink}
+                integrationName={integr_name}
+                integrationProject={project_path}
+                integrationPath={integr_config_path}
+                shouldBeDisabled={
+                  smartlink.sl_enable_only_with_tool
+                    ? !availabilityValues.on_your_laptop
+                    : false
+                }
+              />
+            );
+          })}
+        </Flex>
+        {config.host !== "vscode" && (
+          <Button
+            variant="outline"
+            color="gray"
+            type="button"
+            title={`Open ${integr_name}.yaml configuration file in your IDE`}
+            onClick={() =>
+              openFile({
+                file_name: integr_config_path,
+                line: 1,
+              })
+            }
+          >
+            Open {integr_name}.yaml
+          </Button>
+        )}
       </Flex>
     </Flex>
   );

--- a/refact-agent/gui/src/components/IntegrationsView/IntegrationForm/FormSmartlinks.tsx
+++ b/refact-agent/gui/src/components/IntegrationsView/IntegrationForm/FormSmartlinks.tsx
@@ -52,7 +52,7 @@ export const FormSmartlinks: FC<FormSmartlinksProps> = ({
             );
           })}
         </Flex>
-        {config.host !== "vscode" && (
+        {config.host !== "web" && (
           <Button
             variant="outline"
             color="gray"

--- a/refact-agent/gui/src/components/IntegrationsView/IntegrationsView.module.css
+++ b/refact-agent/gui/src/components/IntegrationsView/IntegrationsView.module.css
@@ -34,11 +34,22 @@
 
 .popup {
   position: fixed;
-  width: max-content;
   max-width: 80%;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 65px;
+
+  /* position: fixed; */
+  /* width: max-content; */
+  /* max-width: 80%;
   left: 50%;
   translate: -50%;
   background-color: var(--accent-3);
   overflow: hidden;
-  bottom: 65px;
+  bottom: 65px; */
+}
+
+/* styles for IDEs (padding for pages varies on config.host (vscode, jetbrains, web) */
+.popup_ide {
+  max-width: 100vw;
 }

--- a/refact-agent/gui/src/components/IntegrationsView/IntegrationsView.module.css
+++ b/refact-agent/gui/src/components/IntegrationsView/IntegrationsView.module.css
@@ -37,16 +37,8 @@
   max-width: 80%;
   left: 50%;
   transform: translateX(-50%);
-  bottom: 65px;
-
-  /* position: fixed; */
-  /* width: max-content; */
-  /* max-width: 80%;
-  left: 50%;
-  translate: -50%;
   background-color: var(--accent-3);
-  overflow: hidden;
-  bottom: 65px; */
+  bottom: 65px;
 }
 
 /* styles for IDEs (padding for pages varies on config.host (vscode, jetbrains, web) */

--- a/refact-agent/gui/src/components/IntegrationsView/IntegrationsView.tsx
+++ b/refact-agent/gui/src/components/IntegrationsView/IntegrationsView.tsx
@@ -17,6 +17,8 @@ import { IntegrationsHeader } from "./Header/IntegrationsHeader";
 import styles from "./IntegrationsView.module.css";
 import { IntermediateIntegration } from "./IntermediateIntegration";
 import { useIntegrations } from "./hooks/useIntegrations";
+import classNames from "classnames";
+import { selectConfig } from "../../features/Config/configSlice";
 
 type IntegrationViewProps = {
   integrationsMap?: IntegrationWithIconResponse;
@@ -36,6 +38,8 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
   const dispatch = useAppDispatch();
   const globalError = useAppSelector(getErrorMessage);
   const information = useAppSelector(getInformationMessage);
+
+  const config = useAppSelector(selectConfig);
 
   const {
     currentIntegration,
@@ -95,7 +99,11 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
     );
   };
 
-  const renderIntegrationForm = (): ReactNode => {
+  const renderIntegrationForm = ({
+    currentHost,
+  }: {
+    currentHost: string;
+  }): ReactNode => {
     if (!currentIntegration) return null;
 
     return (
@@ -128,7 +136,9 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
             timeout={isDeletingIntegration ? 1000 : 3000}
             mx="0"
             onClick={() => dispatch(clearInformation())}
-            className={styles.popup}
+            className={classNames(styles.popup, {
+              [styles.popup_ide]: currentHost !== "web",
+            })}
           >
             {information}
           </InformationCallout>
@@ -138,7 +148,9 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
             mx="0"
             timeout={3000}
             onClick={() => dispatch(clearError())}
-            className={styles.popup}
+            className={classNames(styles.popup, {
+              [styles.popup_ide]: currentHost !== "web",
+            })}
           >
             {globalError}
           </ErrorCallout>
@@ -167,7 +179,9 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
   if (!integrationsMap) {
     return (
       <ErrorCallout
-        className={styles.popup}
+        className={classNames(styles.popup, {
+          [styles.popup_ide]: config.host !== "web",
+        })}
         mx="0"
         onClick={goBackAndClearError}
       >
@@ -182,7 +196,7 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
     }
 
     if (currentIntegration) {
-      return renderIntegrationForm();
+      return renderIntegrationForm({ currentHost: config.host });
     }
 
     return (
@@ -205,7 +219,9 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
             mx="0"
             timeout={3000}
             onClick={() => dispatch(clearError())}
-            className={styles.popup}
+            className={classNames(styles.popup, {
+              [styles.popup_ide]: config.host !== "web",
+            })}
             preventRetry
           >
             {globalError}

--- a/refact-agent/gui/src/features/PatchesAndDiffsTracker/patchesAndDiffsTrackerSlice.ts
+++ b/refact-agent/gui/src/features/PatchesAndDiffsTracker/patchesAndDiffsTrackerSlice.ts
@@ -1,7 +1,8 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { chatAskQuestionThunk, chatResponse } from "../Chat";
 import { isAssistantMessage, isDiffResponse } from "../../events";
 import { parseOrElse, partition } from "../../utils";
+import { RootState } from "../../app/store";
 
 export type PatchMeta = {
   chatId: string;
@@ -86,46 +87,45 @@ export const patchesAndDiffsTrackerSlice = createSlice({
   },
 
   selectors: {
-    selectUnsentPatchesFilePaths: (state) => {
-      const [unstarted, started] = partition(
-        state.patches,
-        (patchMeta) => patchMeta.started,
-      );
-      const unstaredFilePaths = unstarted.map(
-        (patchMeta) => patchMeta.filePath,
-      );
-      const startedFilePaths = started.map((patchMeta) => patchMeta.filePath);
-      return unstaredFilePaths.filter(
-        (filePath) => !startedFilePaths.includes(filePath),
-      );
-    },
-    selectCompletedPatchesFilePaths: (state) => {
-      const [incomplete, completed] = partition(
-        state.patches,
-        (patchMeta) => patchMeta.completed,
-      );
-      const incompleteFilePaths = incomplete.map(
-        (patchMeta) => patchMeta.filePath,
-      );
-      const completeFilePaths = completed.map(
-        (patchMeta) => patchMeta.filePath,
-      );
-      return completeFilePaths.filter(
-        (filePath) => !incompleteFilePaths.includes(filePath),
-      );
-    },
-
     selectAllFilePaths: (state) => {
       return state.patches.map((patchMeta) => patchMeta.filePath);
     },
   },
 });
 
-export const {
-  selectCompletedPatchesFilePaths,
-  selectUnsentPatchesFilePaths,
-  selectAllFilePaths,
-} = patchesAndDiffsTrackerSlice.selectors;
+export const { selectAllFilePaths } = patchesAndDiffsTrackerSlice.selectors;
+
+export const selectUnsentPatchesFilePaths = createSelector(
+  [(state: RootState) => state.patchesAndDiffsTracker],
+  (state) => {
+    const [unstarted, started] = partition(
+      state.patches,
+      (patchMeta) => patchMeta.started,
+    );
+    const unstartedFilePaths = unstarted.map((patchMeta) => patchMeta.filePath);
+    const startedFilePaths = started.map((patchMeta) => patchMeta.filePath);
+    return unstartedFilePaths.filter(
+      (filePath) => !startedFilePaths.includes(filePath),
+    );
+  },
+);
+
+export const selectCompletedPatchesFilePaths = createSelector(
+  [(state: RootState) => state.patchesAndDiffsTracker],
+  (state) => {
+    const [incomplete, completed] = partition(
+      state.patches,
+      (patchMeta) => patchMeta.completed,
+    );
+    const incompleteFilePaths = incomplete.map(
+      (patchMeta) => patchMeta.filePath,
+    );
+    const completeFilePaths = completed.map((patchMeta) => patchMeta.filePath);
+    return completeFilePaths.filter(
+      (filePath) => !incompleteFilePaths.includes(filePath),
+    );
+  },
+);
 
 export const { setStartedByFilePaths, removePatchMetaByFileNameIfCompleted } =
   patchesAndDiffsTrackerSlice.actions;


### PR DESCRIPTION
PR for this task: [Add "Open <integr_name>.yaml" button for not-erroring integration form](https://refact.fibery.io/Software_Development/Sprint-2025-02-24-516#Task/Add-Open-integr_name-.yaml-button-for-not-erroring-integration-form-924)