### PR TITLE
fix: don't disable send when recommending to start a new chat.

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -14,7 +14,6 @@ import {
   useOnPressedEnter,
   useIsOnline,
   useConfig,
-  useAgentUsage,
   useCapsForToolUse,
   useSendChatRequest,
 } from "../../hooks";
@@ -32,7 +31,6 @@ import { useInputValue } from "./useInputValue";
 import {
   clearInformation,
   getInformationMessage,
-  setInformation,
 } from "../../features/Errors/informationSlice";
 import { InformationCallout } from "../Callout/Callout";
 import { ToolConfirmation } from "./ToolConfirmation";
@@ -82,7 +80,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const information = useAppSelector(getInformationMessage);
   const pauseReasonsWithPause = useAppSelector(getPauseReasonsWithPauseStatus);
   const [helpInfo, setHelpInfo] = React.useState<React.ReactNode | null>(null);
-  const { disableInput, usageLimitExhaustedMessage } = useAgentUsage();
   const isOnline = useIsOnline();
   const { retry } = useSendChatRequest();
 
@@ -185,10 +182,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
 
   const handleSubmit = useCallback(() => {
     const trimmedValue = value.trim();
-    if (disableInput) {
-      const action = setInformation(usageLimitExhaustedMessage);
-      dispatch(action);
-    } else if (!disableSend && trimmedValue.length > 0) {
+    if (!disableSend && trimmedValue.length > 0) {
       const valueIncludingChecks = addCheckboxValuesToInput(
         trimmedValue,
         checkboxes,
@@ -201,11 +195,8 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     }
   }, [
     value,
-    disableInput,
     disableSend,
     checkboxes,
-    usageLimitExhaustedMessage,
-    dispatch,
     setFileInteracted,
     setLineSelectionInteracted,
     onSubmit,
@@ -407,7 +398,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
                 isMultimodalitySupportedForCurrentModel && <AttachFileButton />}
               {/* TODO: Reserved space for microphone button coming later on */}
               <PaperPlaneButton
-                disabled={disableSend || disableInput}
+                disabled={disableSend}
                 title="Send message"
                 size="1"
                 type="submit"

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -45,7 +45,7 @@ import {
   selectIsWaiting,
   selectMessages,
   selectPreventSend,
-  selectThreadMaximumTokens,
+  // selectThreadMaximumTokens,
   selectThreadToolUse,
   selectToolUse,
 } from "../../features/Chat";
@@ -53,7 +53,7 @@ import { telemetryApi } from "../../services/refact";
 import { push } from "../../features/Pages/pagesSlice";
 import { AgentCapabilities } from "./AgentCapabilities";
 import { TokensPreview } from "./TokensPreview";
-import { useUsageCounter } from "../UsageCounter/useUsageCounter";
+// import { useUsageCounter } from "../UsageCounter/useUsageCounter";
 import classNames from "classnames";
 
 export type ChatFormProps = {
@@ -87,12 +87,12 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const threadToolUse = useAppSelector(selectThreadToolUse);
   const messages = useAppSelector(selectMessages);
   const preventSend = useAppSelector(selectPreventSend);
-  const currentThreadMaximumContextTokens = useAppSelector(
-    selectThreadMaximumTokens,
-  );
+  // const currentThreadMaximumContextTokens = useAppSelector(
+  //   selectThreadMaximumTokens,
+  // );
 
-  const { isOverflown: arePromptTokensBiggerThanContext, currentThreadUsage } =
-    useUsageCounter();
+  // const { isOverflown: arePromptTokensBiggerThanContext, currentThreadUsage } =
+  //   useUsageCounter();
 
   const shouldAgentCapabilitiesBeShown = useMemo(() => {
     return threadToolUse === "agent" && toolUse === "agent";
@@ -115,26 +115,16 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const disableSend = useMemo(() => {
     // TODO: if interrupting chat some errors can occur
     if (allDisabled) return true;
-    if (
-      currentThreadMaximumContextTokens &&
-      currentThreadUsage?.prompt_tokens &&
-      currentThreadUsage.prompt_tokens > currentThreadMaximumContextTokens
-    )
-      return false;
-    if (arePromptTokensBiggerThanContext) return true;
+    // if (
+    //   currentThreadMaximumContextTokens &&
+    //   currentThreadUsage?.prompt_tokens &&
+    //   currentThreadUsage.prompt_tokens > currentThreadMaximumContextTokens
+    // )
+    //   return false;
+    // if (arePromptTokensBiggerThanContext) return true;
     if (messages.length === 0) return false;
     return isWaiting || isStreaming || !isOnline || preventSend;
-  }, [
-    isOnline,
-    isStreaming,
-    isWaiting,
-    arePromptTokensBiggerThanContext,
-    currentThreadMaximumContextTokens,
-    currentThreadUsage?.prompt_tokens,
-    preventSend,
-    messages,
-    allDisabled,
-  ]);
+  }, [isOnline, isStreaming, isWaiting, preventSend, messages, allDisabled]);
 
   const { processAndInsertImages } = useAttachedImages();
   const handlePastingFile = useCallback(


### PR DESCRIPTION
Fixes: https://refact.fibery.io/Software_Development/Sprint-2025-02-24-516#Task/Send-is-disabled-on-some-random-conditions-933

Also: https://refact.fibery.io/Software_Development/Sprint-2025-02-24-516#Task/Start-a-new-chat-tip-blocks-chat-too-early-898 if the blocking was the issue.

Caused by blocking the user from sending a messages when recommending they start a new chat.