### PR TITLE
Revert "Revert "fix(model select): gpt-4o / gpt-4o-mini

### DIFF
--- a/refact-agent/gui/src/hooks/useCapsForToolUse.ts
+++ b/refact-agent/gui/src/hooks/useCapsForToolUse.ts
@@ -110,15 +110,14 @@ export function useCapsForToolUse() {
   useEffect(() => {
     if (
       usableModelsForPlan.length > 0 &&
-      usableModelsForPlan.some((elem) => elem.textValue.includes(currentModel))
+      usableModelsForPlan.some((elem) => elem.value === currentModel)
       // !usableModelsForPlan.includes(currentModel)
     ) {
       const models: string[] = usableModelsForPlan.map(
         (elem) => elem.textValue,
       );
       const toChange =
-        models.find((elem) => currentModel.startsWith(elem)) ??
-        (models[0] || "");
+        models.find((elem) => currentModel === elem) ?? (models[0] || "");
 
       setCapModel(toChange);
     }


### PR DESCRIPTION
Fixes: https://refact.fibery.io/Software_Development/Sprint-2025-02-24-516#Task/Model-gpt-4o-mini-is-not-available-for-selection-925

using array methods on a string causes gpt-4o and gpt-4o-mini to incorrectly match on caps selection.""

Accidentally committed on main, then reverted, and this reverts that one.