### PR TITLE
refactor(tool confirmation): add rejection message client side, and remove `tool_confirmation` from chat paramters.

### DIFF
--- a/refact-agent/engine/src/call_validation.rs
+++ b/refact-agent/engine/src/call_validation.rs
@@ -197,8 +197,6 @@ pub struct ChatPost {
     #[serde(default)]
     pub tool_choice: Option<String>,
     #[serde(default)]
-    pub tools_confirmation: bool,
-    #[serde(default)]
     pub checkpoints_enabled: bool,
     #[serde(default)]
     pub only_deterministic_messages: bool,  // means don't sample from the model

--- a/refact-agent/engine/src/http/routers/v1/at_tools.rs
+++ b/refact-agent/engine/src/http/routers/v1/at_tools.rs
@@ -56,7 +56,6 @@ pub struct ToolsExecutePost {
     pub model_name: String,
     pub chat_id: String,
     pub style: Option<String>,
-    pub tools_confirmation: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -230,7 +229,7 @@ pub async fn handle_v1_tools_execute(
         ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("Error getting at_tools: {}", e))
     })?;
     let (messages, tools_ran) = run_tools( // todo: fix typo "runned"
-        ccx_arc.clone(), &mut at_tools, tokenizer.clone(), tools_execute_post.maxgen, &tools_execute_post.messages, &tools_execute_post.style, tools_execute_post.tools_confirmation
+        ccx_arc.clone(), &mut at_tools, tokenizer.clone(), tools_execute_post.maxgen, &tools_execute_post.messages, &tools_execute_post.style
     ).await.map_err(|e| ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("Error running tools: {}", e)))?;
 
     let response = ToolExecuteResponse {

--- a/refact-agent/engine/src/scratchpads/chat_passthrough.rs
+++ b/refact-agent/engine/src/scratchpads/chat_passthrough.rs
@@ -132,9 +132,9 @@ impl ScratchpadAbstract for ChatPassthrough {
         };
         if self.supports_tools {
             (messages, _) = if should_execute_remotely {
-                run_tools_remotely(ccx.clone(), &self.post.model, sampling_parameters_to_patch.max_new_tokens, &messages, &mut self.has_rag_results, &style, self.post.tools_confirmation).await?
+                run_tools_remotely(ccx.clone(), &self.post.model, sampling_parameters_to_patch.max_new_tokens, &messages, &mut self.has_rag_results, &style).await?
             } else {
-                run_tools_locally(ccx.clone(), &mut at_tools, self.t.tokenizer.clone(), sampling_parameters_to_patch.max_new_tokens, &messages, &mut self.has_rag_results, &style, self.post.tools_confirmation).await?
+                run_tools_locally(ccx.clone(), &mut at_tools, self.t.tokenizer.clone(), sampling_parameters_to_patch.max_new_tokens, &messages, &mut self.has_rag_results, &style).await?
             }
         };
 

--- a/refact-agent/engine/tests/emergency_frog_situation/frog.py
+++ b/refact-agent/engine/tests/emergency_frog_situation/frog.py
@@ -29,6 +29,17 @@ class Frog:
     def croak(self, n_times):
         for n in range(n_times):
             print("croak")
+    
+    def swim(self, pond_width, pond_height):
+        print("Swimming...")
+        print("Splash! The frog is moving through the water")
+        self.x += self.vx * DT
+        self.y += self.vy * DT
+        print("Ripple... ripple...")
+        self.bounce_off_banks(pond_width, pond_height)
+        self.x = np.clip(self.x, 0, pond_width)
+        self.y = np.clip(self.y, 0, pond_height)
+        print("The frog swam to position ({:.2f}, {:.2f})".format(self.x, self.y))
 
 
 class AlternativeFrog:

--- a/refact-agent/gui/src/components/ChatForm/ToolConfirmation.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ToolConfirmation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   PATCH_LIKE_FUNCTIONS,
   useAppDispatch,
@@ -88,6 +88,10 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     confirmToolUsage();
   };
 
+  const handleReject = useCallback(() => {
+    rejectToolUsage(toolCallIds);
+  }, [rejectToolUsage, toolCallIds]);
+
   const message = getConfirmationMessage(
     commands,
     rules,
@@ -101,7 +105,7 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     return (
       <PatchConfirmation
         handleAllowForThisChat={handleAllowForThisChat}
-        rejectToolUsage={rejectToolUsage}
+        rejectToolUsage={handleReject}
         confirmToolUsage={confirmToolUsage}
       />
     );
@@ -167,7 +171,7 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
               color="red"
               variant="surface"
               size="1"
-              onClick={rejectToolUsage}
+              onClick={handleReject}
             >
               Stop
             </Button>

--- a/refact-agent/gui/src/features/Chat/Thread/actions.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/actions.ts
@@ -292,17 +292,13 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
     messages: ChatMessages;
     chatId: string;
     tools: ToolCommand[] | null;
-    toolsConfirmed?: boolean;
     checkpointsEnabled?: boolean;
     mode?: LspChatMode; // used once for actions
     // TODO: make a separate function for this... and it'll need to be saved.
   }
 >(
   "chatThread/sendChat",
-  (
-    { messages, chatId, tools, mode, toolsConfirmed, checkpointsEnabled },
-    thunkAPI,
-  ) => {
+  ({ messages, chatId, tools, mode, checkpointsEnabled }, thunkAPI) => {
     const state = thunkAPI.getState();
 
     const thread =
@@ -334,7 +330,6 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
       apiKey: state.config.apiKey,
       port: state.config.lspPort,
       onlyDeterministicMessages,
-      toolsConfirmed: toolsConfirmed,
       checkpointsEnabled,
       integration: thread?.integration,
       mode: realMode,

--- a/refact-agent/gui/src/features/Chat/Thread/reducer.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/reducer.ts
@@ -489,7 +489,7 @@ function messageForToolCall(
   toolCall?: ToolCall,
 ) {
   if (accepted === false && toolCall?.function.name) {
-    `Whoops the user didn't like the command ${toolCall.function.name}. Stop and ask for correction from the user.`;
+    return `Whoops the user didn't like the command ${toolCall.function.name}. Stop and ask for correction from the user.`;
   }
   if (accepted === false) return "The user rejected the changes.";
   if (accepted === true) return "The user accepted the changes.";

--- a/refact-agent/gui/src/features/PatchesAndDiffsTracker/patchesAndDiffsTrackerSlice.ts
+++ b/refact-agent/gui/src/features/PatchesAndDiffsTracker/patchesAndDiffsTrackerSlice.ts
@@ -47,7 +47,6 @@ export const patchesAndDiffsTrackerSlice = createSlice({
 
   extraReducers: (builder) => {
     builder.addCase(chatAskQuestionThunk.pending, (state, action) => {
-      if (!action.meta.arg.toolsConfirmed) return state;
       if (action.meta.arg.messages.length === 0) return state;
       const { messages, chatId } = action.meta.arg;
       const lastMessage = messages[messages.length - 1];

--- a/refact-agent/gui/src/hooks/useSendChatRequest.ts
+++ b/refact-agent/gui/src/hooks/useSendChatRequest.ts
@@ -42,6 +42,7 @@ import {
   clearPauseReasonsAndHandleToolsStatus,
   getToolsConfirmationStatus,
   getToolsInteractionStatus,
+  resetConfirmationInteractedState,
   setPauseReasons,
 } from "../features/ToolConfirmation/confirmationSlice";
 import {
@@ -50,9 +51,11 @@ import {
   setChatMode,
   setIsWaitingForResponse,
   setLastUserMessageId,
+  upsertToolCall,
 } from "../features/Chat";
 
 import { v4 as uuidv4 } from "uuid";
+import { upsertToolCallIntoHistory } from "../features/History/historySlice";
 
 type SubmitHandlerParams =
   | {
@@ -141,8 +144,6 @@ export const useSendChatRequest = () => {
 
       const lastMessage = messages.slice(-1)[0];
 
-      let isCurrentToolCallAPatch = false;
-
       if (
         !isWaiting &&
         !wasInteracted &&
@@ -165,8 +166,6 @@ export const useSendChatRequest = () => {
             dispatch(setPauseReasons(confirmationResponse.pause_reasons));
             return;
           }
-        } else {
-          isCurrentToolCallAPatch = true;
         }
       }
 
@@ -176,11 +175,6 @@ export const useSendChatRequest = () => {
       const mode =
         maybeMode ?? chatModeToLspMode({ toolUse, mode: threadMode });
 
-      const toolsConfirmed =
-        isCurrentToolCallAPatch && isPatchAutomatic
-          ? isPatchAutomatic
-          : areToolsConfirmed;
-
       const maybeLastUserMessageIsFromUser = isUserMessage(lastMessage);
       if (maybeLastUserMessageIsFromUser) {
         dispatch(setLastUserMessageId({ chatId: chatId, messageId: uuidv4() }));
@@ -189,7 +183,6 @@ export const useSendChatRequest = () => {
       const action = chatAskQuestionThunk({
         messages,
         tools,
-        toolsConfirmed,
         checkpointsEnabled,
         chatId,
         mode,
@@ -206,7 +199,6 @@ export const useSendChatRequest = () => {
       chatId,
       threadMode,
       wasInteracted,
-      areToolsConfirmed,
       checkpointsEnabled,
       abortControllers,
       triggerCheckForConfirmation,
@@ -319,16 +311,22 @@ export const useSendChatRequest = () => {
     dispatch(setIsWaitingForResponse(false));
   }, [abort, dispatch]);
 
-  const rejectToolUsage = useCallback(() => {
-    abort();
-    dispatch(
-      clearPauseReasonsAndHandleToolsStatus({
-        wasInteracted: true,
-        confirmationStatus: false,
-      }),
-    );
-    dispatch(setIsWaitingForResponse(false));
-  }, [abort, dispatch]);
+  const rejectToolUsage = useCallback(
+    (toolCallIds: string[]) => {
+      abort();
+
+      toolCallIds.forEach((toolCallId) => {
+        dispatch(
+          upsertToolCallIntoHistory({ toolCallId, chatId, accepted: false }),
+        );
+        dispatch(upsertToolCall({ toolCallId, chatId, accepted: false }));
+      });
+
+      dispatch(resetConfirmationInteractedState());
+      dispatch(setIsWaitingForResponse(false));
+    },
+    [abort, chatId, dispatch],
+  );
 
   const retryFromIndex = useCallback(
     (index: number, question: UserMessage["content"]) => {

--- a/refact-agent/gui/src/services/refact/chat.ts
+++ b/refact-agent/gui/src/services/refact/chat.ts
@@ -145,7 +145,6 @@ export async function sendChat({
   tools,
   port = 8001,
   apiKey,
-  toolsConfirmed = true,
   checkpointsEnabled = true,
   // isConfig = false,
   integration,
@@ -169,7 +168,6 @@ export async function sendChat({
     tools,
     max_tokens: max_new_tokens,
     only_deterministic_messages,
-    tools_confirmation: toolsConfirmed,
     checkpoints_enabled: checkpointsEnabled,
     // chat_id,
     meta: {


### PR DESCRIPTION
Ticket: https://refact.fibery.io/Software_Development/Sprint-2025-02-24-516#Task/Chat-suddenly-stops-if-it-was-manually-stopped-before-917

When pressing stop in the confirmation box, chat should stop. The frontend now adds the `tool` message.
Accept should still work the same.