### PR TITLE
engine: increase payload limit from 2mb to 15mb

### DIFF
--- a/refact-agent/engine/src/http/routers.rs
+++ b/refact-agent/engine/src/http/routers.rs
@@ -1,3 +1,4 @@
+use axum::extract::DefaultBodyLimit;
 use axum::Router;
 use axum::routing::get;
 
@@ -13,4 +14,5 @@ pub fn make_refact_http_server() -> Router {
         .nest("/v1", v1::make_v1_router())
         .nest("/db_v1", v1::make_db_v1_router())
         .route("/build_info", get(info::handle_info))
+        .layer(DefaultBodyLimit::max(2usize.pow(20) * 15)) // new limit of payload 15MB(default: 2MB)
 }


### PR DESCRIPTION
https://refact.fibery.io/Software_Development/Sprint-2025-02-24-516#Task/Payload-Too-Large-issue-593