### PR TITLE
fix(selected snippet): snippet not updating when unchecked

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/useCheckBoxes.ts
+++ b/refact-agent/gui/src/components/ChatForm/useCheckBoxes.ts
@@ -122,7 +122,7 @@ const useAttachSelectedSnippet = (
     });
 
   useEffect(() => {
-    if (!interacted) {
+    if (!interacted || !attachedSelectedSnippet.checked) {
       setAttachedSelectedSnippet((prev) => {
         return {
           ...prev,
@@ -134,7 +134,14 @@ const useAttachSelectedSnippet = (
         };
       });
     }
-  }, [snippet.code, host, label, markdown, interacted]);
+  }, [
+    snippet.code,
+    host,
+    label,
+    markdown,
+    interacted,
+    attachedSelectedSnippet.checked,
+  ]);
 
   const onToggleAttachedSelectedSnippet = useCallback(() => {
     setAttachedSelectedSnippet((prev) => {
@@ -195,7 +202,7 @@ export const useCheckboxes = () => {
         case "selected_lines":
           onToggleAttachedSelectedSnippet();
           setFileInteracted(true);
-          setLineSelectionInteracted((prev) => !prev);
+          setLineSelectionInteracted(true);
           break;
       }
     },


### PR DESCRIPTION
Fixes: https://refact.fibery.io/Software_Development/Sprint-2025-03-10-524#Task/UI-Cannot-attach-selected-lines,-checkbox-is-grey-963

Issue could be recreated by opening an old chat, interacting with the snippet checkbox, then changing the selection.