### PR TITLE
fix(chat request): set max tokens for the model

### DIFF
--- a/refact-agent/gui/src/features/Chat/Thread/actions.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/actions.ts
@@ -148,6 +148,7 @@ export const setIsWaitingForResponse = createAction<boolean>(
   "chatThread/setIsWaiting",
 );
 
+// TBD: maybe remove it's only used by a smart link.
 export const setMaxNewTokens = createAction<number>(
   "chatThread/setMaxNewTokens",
 );
@@ -322,9 +323,10 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
           ? state.chat.thread
           : null;
 
+    const maxTokens = thread?.currentMaximumContextTokens
+      ? thread.currentMaximumContextTokens / 2
+      : DEFAULT_MAX_NEW_TOKENS;
     // TODO: stops the stream.
-    // const onlyDeterministicMessages =
-    //   checkForToolLoop(messages) || !messages.some(isSystemMessage);
 
     const onlyDeterministicMessages = checkForToolLoop(messages);
 
@@ -340,7 +342,7 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
       tools,
       stream: true,
       abortSignal: thunkAPI.signal,
-      max_new_tokens: state.chat.max_new_tokens,
+      max_new_tokens: maxTokens,
       chatId,
       apiKey: state.config.apiKey,
       port: state.config.lspPort,

--- a/refact-agent/gui/src/features/Chat/Thread/reducer.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/reducer.ts
@@ -112,6 +112,7 @@ const createInitialState = ({
     error: null,
     prevent_send: false,
     waiting_for_response: false,
+    // TBD: should be safe to remove?
     max_new_tokens: DEFAULT_MAX_NEW_TOKENS,
     cache: {},
     system_prompt: {},
@@ -352,6 +353,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
     state.waiting_for_response = action.payload;
   });
 
+  // TBD: should be safe to remove?
   builder.addCase(setMaxNewTokens, (state, action) => {
     state.max_new_tokens = action.payload;
   });

--- a/refact-agent/gui/src/features/Chat/Thread/reducer.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/reducer.ts
@@ -43,7 +43,6 @@ import { formatChatResponse } from "./utils";
 import {
   ChatMessages,
   commandsApi,
-  DEFAULT_MAX_NEW_TOKENS,
   isAssistantMessage,
   isChatResponseChoice,
   isDiffMessage,
@@ -112,8 +111,6 @@ const createInitialState = ({
     error: null,
     prevent_send: false,
     waiting_for_response: false,
-    // TBD: should be safe to remove?
-    max_new_tokens: DEFAULT_MAX_NEW_TOKENS,
     cache: {},
     system_prompt: {},
     tool_use,
@@ -355,7 +352,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
 
   // TBD: should be safe to remove?
   builder.addCase(setMaxNewTokens, (state, action) => {
-    state.max_new_tokens = action.payload;
+    state.thread.currentMaximumContextTokens = action.payload;
   });
 
   builder.addCase(fixBrokenToolMessages, (state, action) => {

--- a/refact-agent/gui/src/hooks/useCapsForToolUse.ts
+++ b/refact-agent/gui/src/hooks/useCapsForToolUse.ts
@@ -5,9 +5,11 @@ import { useAppSelector, useGetCapsQuery, useAppDispatch } from ".";
 import {
   getSelectedChatModel,
   setChatModel,
+  setMaxNewTokens,
   setToolUse,
   ToolUse,
 } from "../features/Chat";
+import { DEFAULT_MAX_NEW_TOKENS } from "../services/refact";
 
 // TODO: hard coded for now.
 export const PAID_AGENT_LIST = [
@@ -39,8 +41,11 @@ export function useCapsForToolUse() {
       const model = caps.data?.code_chat_default_model === value ? "" : value;
       const action = setChatModel(model);
       dispatch(action);
+      const tokens =
+        caps.data?.code_chat_models[value]?.n_ctx ?? DEFAULT_MAX_NEW_TOKENS;
+      dispatch(setMaxNewTokens(tokens));
     },
-    [caps.data?.code_chat_default_model, dispatch],
+    [caps.data?.code_chat_default_model, caps.data?.code_chat_models, dispatch],
   );
 
   const isMultimodalitySupportedForCurrentModel = useMemo(() => {

--- a/refact-agent/gui/src/hooks/useLinksFromLsp.ts
+++ b/refact-agent/gui/src/hooks/useLinksFromLsp.ts
@@ -220,6 +220,7 @@ export function useLinksFromLsp() {
         return;
       }
 
+      // TBD: It should be safe to remove this now?
       if (link.link_action === "regenerate-with-increased-context-size") {
         dispatch(setMaxNewTokens(INCREASED_MAX_NEW_TOKENS));
         submit({


### PR DESCRIPTION
fixes: https://refact.fibery.io/Software_Development/Sprint-2025-03-10-524#Task/Error-bad-input,-n_ctx-4096,-max_new_tokens-4096-951

Cause of the issue: there's a smart link that would increment the max_new_tokens parameter passed to `/chat` the same info is also available from `/caps` and `/command-preview`.

The number from caps/preview seems to be more accurate.