### PR TITLE
Revert "fix(chat request): set max tokens for the model"

### DIFF
--- a/refact-agent/gui/src/features/Chat/Thread/actions.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/actions.ts
@@ -150,7 +150,6 @@ export const setIsWaitingForResponse = createAction<boolean>(
   "chatThread/setIsWaiting",
 );
 
-// TBD: maybe remove it's only used by a smart link.
 export const setMaxNewTokens = createAction<number>(
   "chatThread/setMaxNewTokens",
 );
@@ -325,10 +324,9 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
           ? state.chat.thread
           : null;
 
-    const maxTokens = thread?.currentMaximumContextTokens
-      ? thread.currentMaximumContextTokens / 2
-      : DEFAULT_MAX_NEW_TOKENS;
     // TODO: stops the stream.
+    // const onlyDeterministicMessages =
+    //   checkForToolLoop(messages) || !messages.some(isSystemMessage);
 
     const onlyDeterministicMessages = checkForToolLoop(messages);
 
@@ -344,7 +342,7 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
       tools,
       stream: true,
       abortSignal: thunkAPI.signal,
-      max_new_tokens: maxTokens,
+      max_new_tokens: state.chat.max_new_tokens,
       chatId,
       apiKey: state.config.apiKey,
       port: state.config.lspPort,

--- a/refact-agent/gui/src/features/Chat/Thread/reducer.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/reducer.ts
@@ -44,6 +44,7 @@ import { formatChatResponse } from "./utils";
 import {
   ChatMessages,
   commandsApi,
+  DEFAULT_MAX_NEW_TOKENS,
   isAssistantMessage,
   isDiffMessage,
   isMultiModalToolResult,
@@ -114,6 +115,7 @@ const createInitialState = ({
     error: null,
     prevent_send: false,
     waiting_for_response: false,
+    max_new_tokens: DEFAULT_MAX_NEW_TOKENS,
     cache: {},
     system_prompt: {},
     tool_use,
@@ -381,9 +383,8 @@ export const chatReducer = createReducer(initialState, (builder) => {
     state.waiting_for_response = action.payload;
   });
 
-  // TBD: should be safe to remove?
   builder.addCase(setMaxNewTokens, (state, action) => {
-    state.thread.currentMaximumContextTokens = action.payload;
+    state.max_new_tokens = action.payload;
   });
 
   builder.addCase(fixBrokenToolMessages, (state, action) => {

--- a/refact-agent/gui/src/hooks/useCapsForToolUse.ts
+++ b/refact-agent/gui/src/hooks/useCapsForToolUse.ts
@@ -5,11 +5,9 @@ import { useAppSelector, useGetCapsQuery, useAppDispatch } from ".";
 import {
   getSelectedChatModel,
   setChatModel,
-  setMaxNewTokens,
   setToolUse,
   ToolUse,
 } from "../features/Chat";
-import { DEFAULT_MAX_NEW_TOKENS } from "../services/refact";
 
 // TODO: hard coded for now.
 export const PAID_AGENT_LIST = [
@@ -41,11 +39,8 @@ export function useCapsForToolUse() {
       const model = caps.data?.code_chat_default_model === value ? "" : value;
       const action = setChatModel(model);
       dispatch(action);
-      const tokens =
-        caps.data?.code_chat_models[value]?.n_ctx ?? DEFAULT_MAX_NEW_TOKENS;
-      dispatch(setMaxNewTokens(tokens));
     },
-    [caps.data?.code_chat_default_model, caps.data?.code_chat_models, dispatch],
+    [caps.data?.code_chat_default_model, dispatch],
   );
 
   const isMultimodalitySupportedForCurrentModel = useMemo(() => {

--- a/refact-agent/gui/src/hooks/useLinksFromLsp.ts
+++ b/refact-agent/gui/src/hooks/useLinksFromLsp.ts
@@ -220,7 +220,6 @@ export function useLinksFromLsp() {
         return;
       }
 
-      // TBD: It should be safe to remove this now?
       if (link.link_action === "regenerate-with-increased-context-size") {
         dispatch(setMaxNewTokens(INCREASED_MAX_NEW_TOKENS));
         submit({


### PR DESCRIPTION
Reverts smallcloudai/refact#600
May have introduced a regression where tool calls end up like this when using explore mode + gpt-4
```
"{\"symbol\":\"Frog\"}{\"query\":\"struct Frog\",\"scope\":\"workspace\"}{\"query\":\"struct Frog\",\"scope\":\"workspace\"}{\"query\":\"struct Frog\",\"scope\":\"workspace\"}"
```