### PR TITLE
fix: change boxes after the user has started typing but not interacted with the checkboxes

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -231,8 +231,11 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     (command: string) => {
       setValue(command);
       const trimmedCommand = command.trim();
-      setFileInteracted(!!trimmedCommand);
-      setLineSelectionInteracted(!!trimmedCommand);
+      if (!trimmedCommand) {
+        setFileInteracted(false);
+        setLineSelectionInteracted(false);
+      }
+
       if (trimmedCommand === "@help") {
         handleHelpInfo(helpText()); // This line has been fixed
       } else {


### PR DESCRIPTION
issue:

When the user has not interacted with the checkboxes and begins typing the values do not update when they select other snippets.