### PR TITLE
wip: remove attach file checkbox.

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Switch,
   Badge,
+  Button,
 } from "@radix-ui/themes";
 import { Select } from "../Select";
 import { type Config } from "../../features/Config/configSlice";
@@ -36,6 +37,7 @@ import {
   setToolUse,
 } from "../../features/Chat/Thread";
 import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
+import { useAttachedFiles } from "./useCheckBoxes";
 
 export const ApplyPatchSwitch: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -223,6 +225,7 @@ export type ChatControlsProps = {
   ) => void;
 
   host: Config["host"];
+  attachedFiles: ReturnType<typeof useAttachedFiles>;
 };
 
 const ChatControlCheckBox: React.FC<{
@@ -294,6 +297,7 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
   checkboxes,
   onCheckedChange,
   host,
+  attachedFiles,
 }) => {
   const refs = useTourRefs();
   const dispatch = useAppDispatch();
@@ -342,6 +346,18 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
           />
         );
       })}
+
+      {host !== "web" && (
+        <Button
+          title="Attach current file"
+          onClick={attachedFiles.addFile}
+          disabled={!attachedFiles.activeFile.name || attachedFiles.attached}
+          size="1"
+          radius="medium"
+        >
+          Attach: {attachedFiles.activeFile.name}
+        </Button>
+      )}
 
       {showControls && (
         <Flex gap="2" direction="column">

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.test.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.test.tsx
@@ -115,11 +115,7 @@ describe("ChatForm", () => {
     await user.type(textarea, "foo");
     await user.keyboard("{Enter}");
     const markdown = "```python\nprint(1)\n```\n";
-    const cursor = app.store.getState().active_file.cursor;
-
-    const expected = `@file foo.txt:${
-      cursor ? cursor + 1 : 1
-    }\n${markdown}\nfoo\n`;
+    const expected = `${markdown}\nfoo\n`;
     expect(fakeOnSubmit).toHaveBeenCalledWith(expected);
   });
 

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -19,7 +19,6 @@ import {
   useSendChatRequest,
   useCompressChat,
   useAutoFocusOnce,
-  // useTotalTokenUsage,
 } from "../../hooks";
 import { ErrorCallout, Callout } from "../Callout";
 import { ComboBox } from "../ComboBox";
@@ -35,7 +34,6 @@ import { useInputValue } from "./useInputValue";
 import {
   clearInformation,
   getInformationMessage,
-  // setInformation,
 } from "../../features/Errors/informationSlice";
 import { InformationCallout } from "../Callout/Callout";
 import { ToolConfirmation } from "./ToolConfirmation";
@@ -51,7 +49,6 @@ import {
   selectLastSentCompression,
   selectMessages,
   selectPreventSend,
-  // selectThreadMaximumTokens,
   selectThreadToolUse,
   selectToolUse,
 } from "../../features/Chat";
@@ -59,7 +56,6 @@ import { telemetryApi } from "../../services/refact";
 import { push } from "../../features/Pages/pagesSlice";
 import { AgentCapabilities } from "./AgentCapabilities";
 import { TokensPreview } from "./TokensPreview";
-// import { useUsageCounter } from "../UsageCounter/useUsageCounter";
 import classNames from "classnames";
 import { ArchiveIcon } from "@radix-ui/react-icons";
 
@@ -161,7 +157,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     checkboxes,
     onToggleCheckbox,
     unCheckAll,
-    setFileInteracted,
     setLineSelectionInteracted,
   } = useCheckboxes();
 
@@ -188,7 +183,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         trimmedValue,
         checkboxes,
       );
-      setFileInteracted(false);
       setLineSelectionInteracted(false);
       onSubmit(valueIncludingChecks);
       setValue(() => "");
@@ -198,7 +192,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     value,
     disableSend,
     checkboxes,
-    setFileInteracted,
     setLineSelectionInteracted,
     onSubmit,
     setValue,
@@ -241,7 +234,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
       setValue(command);
       const trimmedCommand = command.trim();
       if (!trimmedCommand) {
-        setFileInteracted(false);
         setLineSelectionInteracted(false);
       }
 
@@ -251,7 +243,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         handleHelpInfo(null);
       }
     },
-    [handleHelpInfo, setValue, setFileInteracted, setLineSelectionInteracted],
+    [handleHelpInfo, setValue, setLineSelectionInteracted],
   );
 
   const handleAgentIntegrationsClick = useCallback(() => {

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -190,6 +190,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
       onSubmit(valueIncludingChecks);
       setValue(() => "");
       unCheckAll();
+      attachedFiles.removeAll();
     }
   }, [
     value,

--- a/refact-agent/gui/src/components/ChatForm/useCheckBoxes.ts
+++ b/refact-agent/gui/src/components/ChatForm/useCheckBoxes.ts
@@ -51,6 +51,10 @@ export function useAttachedFiles() {
     [files],
   );
 
+  const removeAll = useCallback(() => {
+    setFiles([]);
+  }, []);
+
   useEffect(() => {
     const handleIdeAttachFile = (filePath: string) => {
       const fileInfo: FileInfo = {
@@ -87,6 +91,7 @@ export function useAttachedFiles() {
     removeFile,
     attached,
     addFilesToInput,
+    removeAll,
   };
 }
 

--- a/refact-agent/gui/src/components/ChatForm/useCheckBoxes.ts
+++ b/refact-agent/gui/src/components/ChatForm/useCheckBoxes.ts
@@ -21,7 +21,8 @@ const messageLengthSelector = createSelector(
   (messages) => messages.length,
 );
 
-const useAttachActiveFile = (
+// TODO: delete this
+const _useAttachActiveFile = (
   interacted: boolean,
   hasSnippet: boolean,
 ): [Checkbox, () => void] => {
@@ -167,66 +168,45 @@ const useAttachSelectedSnippet = (
 };
 
 export type Checkboxes = {
-  file_upload: Checkbox;
+  // file_upload: Checkbox;
   selected_lines: Checkbox;
 };
 
 export const useCheckboxes = () => {
-  // creating 2 different states instead of only one being used for both checkboxes
+  // creating different states instead of only one being used for checkboxes
   const [lineSelectionInteracted, setLineSelectionInteracted] = useState(false);
-  const [fileInteracted, setFileInteracted] = useState(false);
 
   const [attachedSelectedSnippet, onToggleAttachedSelectedSnippet] =
     useAttachSelectedSnippet(lineSelectionInteracted);
 
-  const [attachFileCheckboxData, onToggleAttachFile] = useAttachActiveFile(
-    fileInteracted,
-    attachedSelectedSnippet.checked,
-  );
-
   const checkboxes = useMemo(
     () => ({
-      file_upload: attachFileCheckboxData,
       selected_lines: attachedSelectedSnippet,
     }),
-    [attachFileCheckboxData, attachedSelectedSnippet],
+    [attachedSelectedSnippet],
   );
 
   const onToggleCheckbox = useCallback(
     (name: string) => {
       switch (name) {
-        case "file_upload":
-          onToggleAttachFile();
-          setFileInteracted(true);
-          break;
         case "selected_lines":
           onToggleAttachedSelectedSnippet();
-          setFileInteracted(true);
           setLineSelectionInteracted(true);
           break;
       }
     },
-    [onToggleAttachFile, onToggleAttachedSelectedSnippet],
+    [onToggleAttachedSelectedSnippet],
   );
 
   const unCheckAll = useCallback(() => {
-    if (attachFileCheckboxData.checked) {
-      onToggleAttachFile();
-    }
     if (attachedSelectedSnippet.checked) {
       onToggleAttachedSelectedSnippet();
     }
-  }, [
-    attachFileCheckboxData.checked,
-    attachedSelectedSnippet.checked,
-    onToggleAttachFile,
-    onToggleAttachedSelectedSnippet,
-  ]);
+  }, [attachedSelectedSnippet.checked, onToggleAttachedSelectedSnippet]);
 
   return {
     checkboxes,
     onToggleCheckbox,
-    setFileInteracted,
     setLineSelectionInteracted,
     unCheckAll,
   };

--- a/refact-agent/gui/src/components/ChatForm/useCommandCompletionAndPreviewFiles.ts
+++ b/refact-agent/gui/src/components/ChatForm/useCommandCompletionAndPreviewFiles.ts
@@ -110,8 +110,7 @@ function useGetCommandPreviewQuery(
 function useGetPreviewFiles(query: string, checkboxes: Checkboxes) {
   const queryWithCheckboxes = useMemo(
     () => addCheckboxValuesToInput(query, checkboxes),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [checkboxes, query, checkboxes.file_upload.value],
+    [checkboxes, query],
   );
   const [previewQuery, setPreviewQuery] = useState<string>(queryWithCheckboxes);
 
@@ -125,11 +124,7 @@ function useGetPreviewFiles(query: string, checkboxes: Checkboxes) {
 
   useEffect(() => {
     debounceSetPreviewQuery(queryWithCheckboxes);
-  }, [
-    debounceSetPreviewQuery,
-    queryWithCheckboxes,
-    checkboxes.file_upload.value,
-  ]);
+  }, [debounceSetPreviewQuery, queryWithCheckboxes]);
 
   const previewFileResponse = useGetCommandPreviewQuery(previewQuery);
   return previewFileResponse;

--- a/refact-agent/gui/src/components/ChatForm/utils.ts
+++ b/refact-agent/gui/src/components/ChatForm/utils.ts
@@ -16,10 +16,6 @@ export function addCheckboxValuesToInput(
     result = `${checkboxes.selected_lines.value ?? ""}\n` + result;
   }
 
-  if (checkboxes.file_upload.checked && checkboxes.file_upload.hide !== true) {
-    result = `@file ${checkboxes.file_upload.value ?? ""}\n` + result;
-  }
-
   if (!result.endsWith("\n")) {
     result += "\n";
   }
@@ -27,6 +23,7 @@ export function addCheckboxValuesToInput(
   return result;
 }
 
+// TODO: delete this if unused
 export function activeFileToContextFile(fileInfo: FileInfo): ChatContextFile {
   const content = fileInfo.content ?? "";
   return {

--- a/refact-agent/gui/src/components/Dropzone/Dropzone.tsx
+++ b/refact-agent/gui/src/components/Dropzone/Dropzone.tsx
@@ -6,6 +6,7 @@ import { useAttachedImages } from "../../hooks/useAttachedImages";
 import { TruncateLeft } from "../Text";
 import { telemetryApi } from "../../services/refact/telemetry";
 import { useCapsForToolUse } from "../../hooks";
+import { useAttachedFiles } from "../ChatForm/useCheckBoxes";
 
 export const FileUploadContext = createContext<{
   open: () => void;
@@ -77,7 +78,7 @@ export const DropzoneProvider: React.FC<
 
 export const DropzoneConsumer = FileUploadContext.Consumer;
 
-export const AttachFileButton = () => {
+export const AttachImagesButton = () => {
   const [sendTelemetryEvent] =
     telemetryApi.useLazySendTelemetryChatEventQuery();
   const attachFileOnClick = useCallback(
@@ -121,29 +122,52 @@ export const AttachFileButton = () => {
   );
 };
 
-export const FileList = () => {
+type FileListProps = {
+  attachedFiles: ReturnType<typeof useAttachedFiles>;
+};
+export const FileList: React.FC<FileListProps> = ({ attachedFiles }) => {
   const { images, removeImage } = useAttachedImages();
-  if (images.length === 0) return null;
+  if (images.length === 0 && attachedFiles.files.length === 0) return null;
   return (
     <Flex wrap="wrap" gap="1" py="2">
       {images.map((file, index) => {
         const key = `image-${file.name}-${index}`;
         return (
-          <Button
-            // variant="surface"
-            // variant="outline"
-            variant="soft"
-            radius="full"
+          <FileButton
             key={key}
-            size="1"
             onClick={() => removeImage(index)}
-            style={{ maxWidth: "100%" }}
-          >
-            <TruncateLeft wrap="wrap">{file.name}</TruncateLeft>{" "}
-            <Cross1Icon width="10" style={{ flexShrink: 0 }} />
-          </Button>
+            fileName={file.name}
+          />
+        );
+      })}
+      {attachedFiles.files.map((file, index) => {
+        const key = `file-${file.path}-${index}`;
+        return (
+          <FileButton
+            key={key}
+            fileName={file.name}
+            onClick={() => attachedFiles.removeFile(file)}
+          />
         );
       })}
     </Flex>
+  );
+};
+
+const FileButton: React.FC<{ fileName: string; onClick: () => void }> = ({
+  fileName,
+  onClick,
+}) => {
+  return (
+    <Button
+      variant="soft"
+      radius="full"
+      size="1"
+      onClick={onClick}
+      style={{ maxWidth: "100%" }}
+    >
+      <TruncateLeft wrap="wrap">{fileName}</TruncateLeft>{" "}
+      <Cross1Icon width="10" style={{ flexShrink: 0 }} />
+    </Button>
   );
 };

--- a/refact-agent/gui/src/components/Dropzone/index.tsx
+++ b/refact-agent/gui/src/components/Dropzone/index.tsx
@@ -2,6 +2,6 @@ export {
   DropzoneProvider,
   DropzoneConsumer,
   FileUploadContext,
-  AttachFileButton,
+  AttachImagesButton,
   FileList,
 } from "./Dropzone";

--- a/refact-agent/gui/src/events/index.ts
+++ b/refact-agent/gui/src/events/index.ts
@@ -78,6 +78,8 @@ export {
   ideToolCallResponse,
 } from "../hooks/useEventBusForIDE";
 
+export { ideAttachFileToChat } from "../hooks/useEventBusForApp";
+
 export const fim = {
   request,
   ready,

--- a/refact-agent/gui/src/hooks/index.ts
+++ b/refact-agent/gui/src/hooks/index.ts
@@ -35,3 +35,4 @@ export * from "./useCompressChat";
 export * from "./useAutoFocusOnce";
 export * from "./useHideScroll";
 export * from "./useCompressionStop";
+export * from "./useEventBusForApp";

--- a/refact-agent/gui/src/hooks/useEventBusForApp.ts
+++ b/refact-agent/gui/src/hooks/useEventBusForApp.ts
@@ -13,6 +13,9 @@ import {
   selectPages,
 } from "../features/Pages/pagesSlice";
 import { ideToolCallResponse } from "./useEventBusForIDE";
+import { createAction } from "@reduxjs/toolkit/react";
+
+export const ideAttachFileToChat = createAction<string>("ide/attachFileToChat");
 
 export function useEventBusForApp() {
   const config = useConfig();


### PR DESCRIPTION
Ticket: https://refact.fibery.io/Software_Development/Sprint-2025-03-24-530#Task/UI-Attach-multiple-files-976

First task only.

Changes the attach file check box to a button.
Also: active file is no longer attached by default.

To test: compile and run in vscode to see the button
