### PR TITLE
fix: set body class when appearance changes.

### DIFF
--- a/refact-agent/gui/src/app/middleware.ts
+++ b/refact-agent/gui/src/app/middleware.ts
@@ -28,7 +28,7 @@ import {
   setError,
   setIsAuthError,
 } from "../features/Errors/errorsSlice";
-import { updateConfig } from "../features/Config/configSlice";
+import { setThemeMode, updateConfig } from "../features/Config/configSlice";
 import { resetAttachedImagesSlice } from "../features/AttachedImages";
 import { nextTip } from "../features/TipOfTheDay";
 import { telemetryApi } from "../services/refact/telemetry";
@@ -525,6 +525,21 @@ startListening({
           agent_usage: 0,
         }),
       );
+    }
+  },
+});
+
+startListening({
+  matcher: isAnyOf(updateConfig.match, setThemeMode.match),
+  effect: (_action, listenerApi) => {
+    const appearance = listenerApi.getState().config.themeProps.appearance;
+    if (appearance === "light" && document.body.className !== "vscode-light") {
+      document.body.className = "vscode-light";
+    } else if (
+      appearance === "dark" &&
+      document.body.className !== "vscode-dark"
+    ) {
+      document.body.className = "vscode-dark";
     }
   },
 });


### PR DESCRIPTION
Ticket: https://refact.fibery.io/Software_Development/All-Tasks-by-state-40#Task/JB-Chat-interface-does-not-display-correctly-in-Light-theme-568

basically the body class wasn't being updated when the `appearance` property changed.

Could be recreated in the web version by clicking the theme button then the menu button.