### PR TITLE
current model fallback setup

### DIFF
--- a/refact-agent/engine/src/agentic/compress_trajectory.rs
+++ b/refact-agent/engine/src/agentic/compress_trajectory.rs
@@ -112,17 +112,16 @@ pub async fn compress_trajectory(
             ..Default::default()
         },
     );
-    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(
-        AtCommandsContext::new(
-            gcx.clone(),
-            n_ctx,
-            1,
-            false,
-            messages_compress.clone(),
-            "".to_string(),
-            false,
-        ).await,
-    ));
+    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(AtCommandsContext::new(
+        gcx.clone(),
+        n_ctx,
+        1,
+        false,
+        messages_compress.clone(),
+        "".to_string(),
+        false,
+        model_name.clone(),
+    ).await));
     let tools = gather_used_tools(&messages);
     let new_messages = subchat_single(
         ccx.clone(),

--- a/refact-agent/engine/src/agentic/generate_commit_message.rs
+++ b/refact-agent/engine/src/agentic/generate_commit_message.rs
@@ -272,18 +272,16 @@ pub async fn generate_commit_message_by_diff(
             .map_err(|_| "Caps are not available".to_string())?,
         Err(_) => Err("No caps available".to_string()),
     }?;
-    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(
-        AtCommandsContext::new(
-            gcx.clone(),
-            N_CTX,
-            1,
-            false,
-            messages.clone(),
-            "".to_string(),
-            false,
-        )
-            .await,
-    ));
+    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(AtCommandsContext::new(
+        gcx.clone(),
+        N_CTX,
+        1,
+        false,
+        messages.clone(),
+        "".to_string(),
+        false,
+        model_name.clone(),
+    ).await));
     let new_messages = subchat_single(
         ccx.clone(),
         model_name.as_str(),

--- a/refact-agent/engine/src/agentic/generate_follow_up_message.rs
+++ b/refact-agent/engine/src/agentic/generate_follow_up_message.rs
@@ -86,6 +86,7 @@ pub async fn generate_follow_up_message(
         messages.clone(),
         chat_id.to_string(),
         false,
+        current_model_name.clone(),
     ).await));
     let model_name = light_model_name.unwrap_or(current_model_name.to_string());
     let updated_messages: Vec<Vec<ChatMessage>> = subchat_single(

--- a/refact-agent/engine/src/agentic/generate_follow_up_message.rs
+++ b/refact-agent/engine/src/agentic/generate_follow_up_message.rs
@@ -74,7 +74,7 @@ fn _make_conversation(
 pub async fn generate_follow_up_message(
     messages: Vec<ChatMessage>,
     gcx: Arc<ARwLock<GlobalContext>>,
-    light_model_name: Option<String>,
+    light_model_name: String,
     current_model_name: &String,
     chat_id: &str,
 ) -> Result<FollowUpResponse, String> {
@@ -88,10 +88,9 @@ pub async fn generate_follow_up_message(
         false,
         current_model_name.clone(),
     ).await));
-    let model_name = light_model_name.unwrap_or(current_model_name.to_string());
     let updated_messages: Vec<Vec<ChatMessage>> = subchat_single(
         ccx.clone(),
-        &model_name,
+        &light_model_name,
         _make_conversation(&messages),
         Some(vec![]),
         None,

--- a/refact-agent/engine/src/at_commands/at_commands.rs
+++ b/refact-agent/engine/src/at_commands/at_commands.rs
@@ -49,6 +49,7 @@ impl AtCommandsContext {
         messages: Vec<ChatMessage>,
         chat_id: String,
         should_execute_remotely: bool,
+        current_model: String,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<serde_json::Value>();
         AtCommandsContext {
@@ -61,7 +62,7 @@ impl AtCommandsContext {
             pp_skeleton: true,
             correction_only_up_to_step: 0,
             chat_id,
-            current_model: "".to_string(),
+            current_model,
             should_execute_remotely,
 
             at_commands: at_commands_dict(global_context.clone()).await,

--- a/refact-agent/engine/src/autonomy.rs
+++ b/refact-agent/engine/src/autonomy.rs
@@ -200,6 +200,7 @@ async fn do_the_job(
         messages.clone(),
         cthread_rec.cthread_id.clone(),
         false,
+        cthread_rec.cthread_model.clone(),
     ).await));
     let log_prefix = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
     let chat_response_msgs = subchat_single(

--- a/refact-agent/engine/src/http/routers/v1/at_commands.rs
+++ b/refact-agent/engine/src/http/routers/v1/at_commands.rs
@@ -97,6 +97,7 @@ pub async fn handle_v1_command_completion(
         vec![],
         "".to_string(),
         false,
+        "".to_string(),
     ).await));
 
     let at_commands = {
@@ -199,6 +200,7 @@ pub async fn handle_v1_command_preview(
         vec![],
         "".to_string(),
         false,
+        model_name.clone(),
     ).await));
 
     let (messages_for_postprocessing, vec_highlights) = execute_at_commands_in_query(
@@ -300,6 +302,7 @@ pub async fn handle_v1_at_command_execute(
         vec![],
         "".to_string(),
         false,
+        post.model_name.clone(),
     ).await;
     ccx.subchat_tool_parameters = post.subchat_tool_parameters.clone();
     ccx.postprocess_parameters = post.postprocess_parameters.clone();

--- a/refact-agent/engine/src/http/routers/v1/at_tools.rs
+++ b/refact-agent/engine/src/http/routers/v1/at_tools.rs
@@ -133,7 +133,14 @@ pub async fn handle_v1_tools_check_if_confirmation_needed(
     }
 
     let ccx = Arc::new(AMutex::new(AtCommandsContext::new(
-        gcx.clone(), 1000, 1, false, post.messages.clone(), "".to_string(), false
+        gcx.clone(),
+        1000,
+        1,
+        false,
+        post.messages.clone(),
+        "".to_string(),
+        false,
+        "".to_string(),
     ).await)); // used only for should_confirm
 
     let all_tools = match tools_merged_and_filtered(gcx.clone(), true).await {
@@ -230,6 +237,7 @@ pub async fn handle_v1_tools_execute(
         tools_execute_post.messages.clone(),
         tools_execute_post.chat_id.clone(),
         false,
+        tools_execute_post.model_name.clone(),
     ).await;
     ccx.subchat_tool_parameters = tools_execute_post.subchat_tool_parameters.clone();
     ccx.postprocess_parameters = tools_execute_post.postprocess_parameters.clone();

--- a/refact-agent/engine/src/http/routers/v1/chat.rs
+++ b/refact-agent/engine/src/http/routers/v1/chat.rs
@@ -287,6 +287,7 @@ async fn _chat(
         messages.clone(),
         chat_post.meta.chat_id.clone(),
         should_execute_remotely,
+        model_name.clone(),
     ).await;
     ccx.subchat_tool_parameters = chat_post.subchat_tool_parameters.clone();
     ccx.postprocess_parameters = chat_post.postprocess_parameters.clone();

--- a/refact-agent/engine/src/http/routers/v1/code_completion.rs
+++ b/refact-agent/engine/src/http/routers/v1/code_completion.rs
@@ -128,6 +128,7 @@ pub async fn handle_v1_code_completion(
         vec![],
         "".to_string(),
         false,
+        code_completion_post.model.clone(),
     ).await));
     if !code_completion_post.stream {
         crate::restream::scratchpad_interaction_not_stream(ccx.clone(), &mut scratchpad, "completion".to_string(), model_name, &mut code_completion_post.parameters, false, None).await
@@ -195,6 +196,7 @@ pub async fn handle_v1_code_completion_prompt(
         vec![],
         "".to_string(),
         false,
+        model_name.clone(),
     ).await));
     let prompt = scratchpad.prompt(ccx.clone(), &mut post.parameters).await.map_err(|e|
         ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("Prompt: {}", e))

--- a/refact-agent/engine/src/http/routers/v1/links.rs
+++ b/refact-agent/engine/src/http/routers/v1/links.rs
@@ -13,6 +13,10 @@ use crate::agentic::generate_follow_up_message::generate_follow_up_message;
 use crate::git::commit_info::{get_commit_information_from_current_changes, generate_commit_messages};
 // use crate::http::routers::v1::git::GitCommitPost;
 
+
+// TODO: remove this dirty hack when we add light_chat_model in caps
+const LIGHT_MODEL_NAME: &str = "gpt-4o-mini";
+
 #[derive(Deserialize, Clone, Debug)]
 pub struct LinksPost {
     messages: Vec<ChatMessage>,
@@ -344,7 +348,7 @@ pub async fn handle_v1_links(
         && post.messages.last().map(|x| x.role == "assistant").unwrap_or(false)
     {
         let follow_up_response = generate_follow_up_message(
-            post.messages.clone(), gcx.clone(), Some("gpt-4o-mini".to_string()), &post.model_name, &post.meta.chat_id
+            post.messages.clone(), gcx.clone(), LIGHT_MODEL_NAME.to_string(), &post.model_name, &post.meta.chat_id
         ).await
             .map_err(|e| ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("Error generating follow-up message: {}", e)))?;
         new_chat_suggestion = follow_up_response.topic_changed;

--- a/refact-agent/engine/src/http/routers/v1/subchat.rs
+++ b/refact-agent/engine/src/http/routers/v1/subchat.rs
@@ -32,9 +32,16 @@ pub async fn handle_v1_subchat(
 
     let top_n = 7;
     let fake_n_ctx = 4096;
-    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(
-        AtCommandsContext::new(global_context.clone(), fake_n_ctx, top_n, false, messages.clone(), "".to_string(), false).await
-    ));
+    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(AtCommandsContext::new(
+        global_context.clone(),
+        fake_n_ctx,
+        top_n,
+        false,
+        messages.clone(),
+        "".to_string(),
+        false,
+        post.model_name.clone(),
+    ).await));
 
     let new_messages = subchat(
         ccx.clone(),
@@ -89,9 +96,16 @@ pub async fn handle_v1_subchat_single(
 
     let top_n = 7;
     let fake_n_ctx = 4096;
-    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(
-        AtCommandsContext::new(global_context.clone(), fake_n_ctx, top_n, false, messages.clone(), "".to_string(), false).await)
-    );
+    let ccx: Arc<AMutex<AtCommandsContext>> = Arc::new(AMutex::new(AtCommandsContext::new(
+        global_context.clone(),
+        fake_n_ctx,
+        top_n,
+        false,
+        messages.clone(),
+        "".to_string(),
+        false,
+        post.model_name.clone(),
+    ).await));
 
     let new_messages = subchat_single(
         ccx.clone(),

--- a/refact-agent/engine/src/tools/tool_create_memory_bank.rs
+++ b/refact-agent/engine/src/tools/tool_create_memory_bank.rs
@@ -379,6 +379,7 @@ impl Tool for ToolCreateMemoryBank {
                 ccx_lock.messages.clone(),
                 ccx_lock.chat_id.clone(),
                 ccx_lock.should_execute_remotely,
+                ccx_lock.current_model.clone(),
             ).await;
             ctx.subchat_tx = ccx_lock.subchat_tx.clone();
             ctx.subchat_rx = ccx_lock.subchat_rx.clone();

--- a/refact-agent/engine/src/tools/tool_deep_analysis.rs
+++ b/refact-agent/engine/src/tools/tool_deep_analysis.rs
@@ -136,6 +136,7 @@ impl Tool for ToolDeepAnalysis {
                 ccx_lock.messages.clone(),
                 ccx_lock.chat_id.clone(),
                 ccx_lock.should_execute_remotely,
+                ccx_lock.current_model.clone(),
             ).await;
             t.subchat_tx = ccx_lock.subchat_tx.clone();
             t.subchat_rx = ccx_lock.subchat_rx.clone();

--- a/refact-agent/engine/src/tools/tool_locate_search.rs
+++ b/refact-agent/engine/src/tools/tool_locate_search.rs
@@ -124,6 +124,7 @@ impl Tool for ToolLocateSearch {
                 ccx_lock.messages.clone(),
                 ccx_lock.chat_id.clone(),
                 ccx_lock.should_execute_remotely,
+                ccx_lock.current_model.clone(),
             ).await;
             t.subchat_tx = ccx_lock.subchat_tx.clone();
             t.subchat_rx = ccx_lock.subchat_rx.clone();

--- a/refact-agent/engine/src/tools/tool_relevant_files.rs
+++ b/refact-agent/engine/src/tools/tool_relevant_files.rs
@@ -92,6 +92,7 @@ impl Tool for ToolRelevantFiles {
                 ccx_lock.messages.clone(),
                 ccx_lock.chat_id.clone(),
                 ccx_lock.should_execute_remotely,
+                ccx_lock.current_model.clone(),
             ).await;
             t.subchat_tx = ccx_lock.subchat_tx.clone();
             t.subchat_rx = ccx_lock.subchat_rx.clone();


### PR DESCRIPTION
current_model in ccx doesn't set up
so if we dont have some subchat model we'll fallback to "" instead of actual chat_model