### PR TITLE
include_non_existent_records flag

### DIFF
--- a/refact-agent/engine/src/http/routers/v1/v1_integrations.rs
+++ b/refact-agent/engine/src/http/routers/v1/v1_integrations.rs
@@ -19,7 +19,7 @@ pub async fn handle_v1_integrations(
     Extension(gcx): Extension<Arc<ARwLock<GlobalContext>>>,
     _: hyper::body::Bytes,
 ) -> axum::response::Result<Response<Body>, ScratchError> {
-    let integrations = crate::integrations::setting_up_integrations::integrations_all(gcx.clone()).await;
+    let integrations = crate::integrations::setting_up_integrations::integrations_all(gcx.clone(), true).await;
     let payload = serde_json::to_string_pretty(&integrations).map_err(|e| {
         ScratchError::new(StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to serialize payload: {}", e))
     })?;
@@ -34,7 +34,7 @@ pub async fn handle_v1_integrations_filtered(
     Extension(gcx): Extension<Arc<ARwLock<GlobalContext>>>,
     Path(integr_name): Path<String>,
 ) -> axum::response::Result<Response<Body>, ScratchError> {
-    let integrations_result: crate::integrations::setting_up_integrations::IntegrationResult = crate::integrations::setting_up_integrations::integrations_all(gcx.clone()).await;
+    let integrations_result: crate::integrations::setting_up_integrations::IntegrationResult = crate::integrations::setting_up_integrations::integrations_all(gcx.clone(), true).await;
     let mut filtered_integrations = Vec::new();
 
     for integration in &integrations_result.integrations {

--- a/refact-agent/engine/src/integrations/config_chat.rs
+++ b/refact-agent/engine/src/integrations/config_chat.rs
@@ -20,7 +20,7 @@ pub async fn mix_config_messages(
     tracing::info!("post.integr_config_path {:?}", chat_meta.current_config_file);
 
     let mut context_file_vec = Vec::new();
-    let all_integrations = crate::integrations::setting_up_integrations::integrations_all(gcx.clone()).await;
+    let all_integrations = crate::integrations::setting_up_integrations::integrations_all(gcx.clone(), false).await;
     for ig in all_integrations.integrations {
         if !ig.integr_config_exists {
             continue;

--- a/refact-agent/engine/src/integrations/project_summary_chat.rs
+++ b/refact-agent/engine/src/integrations/project_summary_chat.rs
@@ -37,7 +37,7 @@ pub async fn mix_project_summary_messages(
     }
 
     if sp_text.contains("%AVAILABLE_INTEGRATIONS%") {
-        let integrations_all = integrations_all(gcx.clone()).await.integrations;
+        let integrations_all = integrations_all(gcx.clone(), false).await.integrations;
         let integrations = integrations_all.iter().filter(|x|x.integr_config_exists && x.project_path.is_empty()).collect::<Vec<_>>();
         sp_text = sp_text.replace("%AVAILABLE_INTEGRATIONS%", &integrations.iter().map(|x|x.integr_name.clone()).collect::<Vec<_>>().join(", "));
     }

--- a/refact-agent/engine/src/integrations/running_integrations.rs
+++ b/refact-agent/engine/src/integrations/running_integrations.rs
@@ -55,6 +55,7 @@ pub async fn load_integrations(
         &lst,
         &mut error_log,
         include_paths_matching,
+        false,
     );
 
     let mut integrations_map = IndexMap::new();


### PR DESCRIPTION
We load integrations almost everywhere for chat purposes.
In case of multiple repos we'll do a lot of unnecessary work listing potential integration records.