### PR TITLE
Fix: format coins pricing

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
@@ -179,7 +179,7 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
         const pricingForModel = caps.data.metadata.pricing[key];
         const tooltip = (
           <Flex direction="column" gap="4">
-            <Text size="1">Cost per Thousand Tokens</Text>
+            <Text size="1">Cost per Million Tokens</Text>
             <DataList.Root size="1" trim="both" className={styles.data_list}>
               {Object.entries(pricingForModel).map(([key, value]) => {
                 return (
@@ -189,7 +189,7 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
                     </DataList.Label>
                     <DataList.Value className={styles.data_list__value}>
                       <Flex justify="between" align="center" gap="2">
-                        {value / 1_000} <Coin width="12px" height="12px" />
+                        {value * 1_000} <Coin width="12px" height="12px" />
                       </Flex>
                     </DataList.Value>
                   </DataList.Item>


### PR DESCRIPTION
With conversion rate 10$ = 10k coins, we should show corresponding values per million tokens as how different providers do
![image](https://github.com/user-attachments/assets/ae07ed9d-dbcf-40dd-b99e-1e0bc2353e1b)
