### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/refact-agent/engine/python_binding_and_cmdline/setup.py
+++ b/refact-agent/engine/python_binding_and_cmdline/setup.py
@@ -17,7 +17,7 @@ class BDistWheel(bdist_wheel):
         return (
             self.python_tag,
             "none",
-            os.environ.get('WHL_TAG', re.sub("[^\w\d]+", "_", sysconfig.get_platform().replace('.', '_'), re.UNICODE))
+            os.environ.get('WHL_TAG', re.sub("[^\w\d]+", "_", sysconfig.get_platform().replace('.', '_'), flgs=re.UNICODE))
         )
 
 cmdclass = {

--- a/refact-agent/engine/python_binding_and_cmdline/setup.py
+++ b/refact-agent/engine/python_binding_and_cmdline/setup.py
@@ -17,7 +17,7 @@ class BDistWheel(bdist_wheel):
         return (
             self.python_tag,
             "none",
-            os.environ.get('WHL_TAG', re.sub("[^\w\d]+", "_", sysconfig.get_platform().replace('.', '_'), flgs=re.UNICODE))
+            os.environ.get('WHL_TAG', re.sub("[^\w\d]+", "_", sysconfig.get_platform().replace('.', '_'), flags=re.UNICODE))
         )
 
 cmdclass = {


### PR DESCRIPTION
# PR Summary
This small PR resolves the `re` deprecation warnings:
```python
DeprecationWarning: 'count' is passed as positional argument
```