### PR TITLE
model list, system prompt list

### DIFF
--- a/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   DataList,
 } from "@radix-ui/themes";
-import { Select } from "../Select";
+import { Select, type SelectProps } from "../Select";
 import { type Config } from "../../features/Config/configSlice";
 import { TruncateLeft } from "../Text";
 import styles from "./ChatForm.module.css";
@@ -170,7 +170,7 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   const refs = useTourRefs();
   const caps = useCapsForToolUse();
   const dispatch = useAppDispatch();
-  
+
   const handleAddNewModelClick = useCallback(() => {
     dispatch(push({ name: "providers page" }));
   }, [dispatch]);
@@ -183,70 +183,64 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
       }
       caps.setCapModel(value);
     },
-    [handleAddNewModelClick, caps]
+    [handleAddNewModelClick, caps],
   );
 
-  const optionsWithToolTips = useMemo(
-    () => {
-      // Map existing models with tooltips
-      const modelOptions = caps.usableModelsForPlan.map((option) => {
-        if (!caps.data) return option;
-        if (!caps.data.metadata) return option;
-        if (!caps.data.metadata.pricing) return option;
-        if (!option.value.startsWith("refact/")) return option;
-        const key = option.value.replace("refact/", "");
-        if (!(key in caps.data.metadata.pricing)) return option;
-        const pricingForModel = caps.data.metadata.pricing[key];
-        const tooltip = (
-          <Flex direction="column" gap="4">
-            <Text size="1">Cost per Million Tokens</Text>
-            <DataList.Root size="1" trim="both" className={styles.data_list}>
-              {Object.entries(pricingForModel).map(([key, value], idx) => {
-                return (
-                  <DataList.Item key={`${option.value}-${key}-${idx}`} align="stretch">
-                    <DataList.Label minWidth="88px">
-                      {toPascalCase(key)}
-                    </DataList.Label>
-                    <DataList.Value className={styles.data_list__value}>
-                      <Flex justify="between" align="center" gap="2">
-                        {value * 1_000} <Coin width="12px" height="12px" />
-                      </Flex>
-                    </DataList.Value>
-                  </DataList.Item>
-                );
-              })}
-            </DataList.Root>
-          </Flex>
-        );
-        return {
-          ...option,
-          tooltip,
-          // title,
-        };
-      });
-      
-      // Add separator and "Add new model" option
-      return [
-        ...modelOptions,
-        { type: 'separator', key: 'add-new-model-separator' }, // Separator line
-        { 
-          value: 'add-new-model', 
-          key: 'add-new-model',
-          children: 'Add new model',
-          textValue: 'Add new model'
-        }
-      ];
-    },
-    [caps.data, caps.usableModelsForPlan],
-  );
+  const optionsWithToolTips: SelectProps["options"] = useMemo(() => {
+    // Map existing models with tooltips
+    const modelOptions = caps.usableModelsForPlan.map((option) => {
+      if (!caps.data) return option;
+      if (!caps.data.metadata) return option;
+      if (!caps.data.metadata.pricing) return option;
+      if (!option.value.startsWith("refact/")) return option;
+      const key = option.value.replace("refact/", "");
+      if (!(key in caps.data.metadata.pricing)) return option;
+      const pricingForModel = caps.data.metadata.pricing[key];
+      const tooltip = (
+        <Flex direction="column" gap="4">
+          <Text size="1">Cost per Million Tokens</Text>
+          <DataList.Root size="1" trim="both" className={styles.data_list}>
+            {Object.entries(pricingForModel).map(([key, value]) => {
+              return (
+                <DataList.Item key={key} align="stretch">
+                  <DataList.Label minWidth="88px">
+                    {toPascalCase(key)}
+                  </DataList.Label>
+                  <DataList.Value className={styles.data_list__value}>
+                    <Flex justify="between" align="center" gap="2">
+                      {value * 1_000} <Coin width="12px" height="12px" />
+                    </Flex>
+                  </DataList.Value>
+                </DataList.Item>
+              );
+            })}
+          </DataList.Root>
+        </Flex>
+      );
+      return {
+        ...option,
+        tooltip,
+        // title,
+      };
+    });
+
+    // Add separator and "Add new model" option
+    return [
+      ...modelOptions,
+      { type: "separator" }, // Separator line
+      {
+        value: "add-new-model",
+        textValue: "Add new model",
+      },
+    ];
+  }, [caps.data, caps.usableModelsForPlan]);
 
   const allDisabled = caps.usableModelsForPlan.every((option) => {
     if (typeof option === "string") return false;
     return option.disabled;
   });
 
-  if (disabled) 
-    return null;
+  if (disabled) return null;
 
   return (
     <Flex

--- a/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
@@ -43,6 +43,7 @@ import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
 import { useAttachedFiles } from "./useCheckBoxes";
 import { toPascalCase } from "../../utils/toPascalCase";
 import { Coin } from "../../images";
+import { push } from "../../features/Pages/pagesSlice";
 
 export const ApplyPatchSwitch: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -168,10 +169,27 @@ export const AgentRollbackSwitch: React.FC = () => {
 export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   const refs = useTourRefs();
   const caps = useCapsForToolUse();
+  const dispatch = useAppDispatch();
+  
+  const handleAddNewModelClick = useCallback(() => {
+    dispatch(push({ name: "providers page" }));
+  }, [dispatch]);
+
+  const onSelectChange = useCallback(
+    (value: string) => {
+      if (value === "add-new-model") {
+        handleAddNewModelClick();
+        return;
+      }
+      caps.setCapModel(value);
+    },
+    [handleAddNewModelClick, caps]
+  );
 
   const optionsWithToolTips = useMemo(
-    () =>
-      caps.usableModelsForPlan.map((option) => {
+    () => {
+      // Map existing models with tooltips
+      const modelOptions = caps.usableModelsForPlan.map((option) => {
         if (!caps.data) return option;
         if (!caps.data.metadata) return option;
         if (!caps.data.metadata.pricing) return option;
@@ -183,9 +201,9 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
           <Flex direction="column" gap="4">
             <Text size="1">Cost per Million Tokens</Text>
             <DataList.Root size="1" trim="both" className={styles.data_list}>
-              {Object.entries(pricingForModel).map(([key, value]) => {
+              {Object.entries(pricingForModel).map(([key, value], idx) => {
                 return (
-                  <DataList.Item key={key} align="stretch">
+                  <DataList.Item key={`${option.value}-${key}-${idx}`} align="stretch">
                     <DataList.Label minWidth="88px">
                       {toPascalCase(key)}
                     </DataList.Label>
@@ -205,7 +223,20 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
           tooltip,
           // title,
         };
-      }),
+      });
+      
+      // Add separator and "Add new model" option
+      return [
+        ...modelOptions,
+        { type: 'separator', key: 'add-new-model-separator' }, // Separator line
+        { 
+          value: 'add-new-model', 
+          key: 'add-new-model',
+          children: 'Add new model',
+          textValue: 'Add new model'
+        }
+      ];
+    },
     [caps.data, caps.usableModelsForPlan],
   );
 
@@ -213,6 +244,9 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
     if (typeof option === "string") return false;
     return option.disabled;
   });
+
+  if (disabled) 
+    return null;
 
   return (
     <Flex
@@ -235,7 +269,7 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
               title="chat model"
               options={optionsWithToolTips}
               value={caps.currentModel}
-              onChange={caps.setCapModel}
+              onChange={onSelectChange}
               disabled={disabled}
             />
           )}

--- a/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatControls.tsx
@@ -224,10 +224,9 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
       };
     });
 
-    // Add separator and "Add new model" option
     return [
       ...modelOptions,
-      { type: "separator" }, // Separator line
+      { type: "separator" },
       {
         value: "add-new-model",
         textValue: "Add new model",
@@ -239,8 +238,6 @@ export const CapsSelect: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
     if (typeof option === "string") return false;
     return option.disabled;
   });
-
-  if (disabled) return null;
 
   return (
     <Flex

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -146,6 +146,8 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     preventSend,
   ]);
 
+  const isModelSelectVisible = useMemo(() => messages.length < 1, [messages]);
+
   const { processAndInsertImages } = useAttachedImages();
   const handlePastingFile = useCallback(
     (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -396,9 +398,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
             )}
           />
           <Flex gap="1" wrap="wrap" py="1" px="2">
-            <CapsSelect
-              disabled={messages.length > 0 || isStreaming || isWaiting}
-            />
+            {isModelSelectVisible && <CapsSelect />}
 
             <Flex justify="end" flexGrow="1" wrap="wrap" gap="2">
               <ThinkingButton />

--- a/refact-agent/gui/src/components/ChatForm/PromptSelect.tsx
+++ b/refact-agent/gui/src/components/ChatForm/PromptSelect.tsx
@@ -63,6 +63,9 @@ export const PromptSelect: React.FC = () => {
     [promptsRequest.isLoading, promptsRequest.isFetching, caps.isLoading],
   );
 
+  if (options.length <= 1) 
+    return null;
+
   return (
     <Flex
       gap="2"

--- a/refact-agent/gui/src/components/ChatForm/PromptSelect.tsx
+++ b/refact-agent/gui/src/components/ChatForm/PromptSelect.tsx
@@ -63,8 +63,7 @@ export const PromptSelect: React.FC = () => {
     [promptsRequest.isLoading, promptsRequest.isFetching, caps.isLoading],
   );
 
-  if (options.length <= 1) 
-    return null;
+  if (options.length <= 1) return null;
 
   return (
     <Flex

--- a/refact-agent/gui/src/components/Select/Select.tsx
+++ b/refact-agent/gui/src/components/Select/Select.tsx
@@ -3,9 +3,16 @@ import { HoverCard, Select as RadixSelect } from "@radix-ui/themes";
 import styles from "./select.module.css";
 import classnames from "classnames";
 
+type SeparatorOption = { type: "separator"; key?: string };
+function isSeparator(option: unknown): option is SeparatorOption {
+  if (!option) return false;
+  if (typeof option !== "object") return false;
+  if (!("type" in option)) return false;
+  return option.type === "separator";
+}
 export type SelectProps = React.ComponentProps<typeof RadixSelect.Root> & {
   onChange: (value: string) => void;
-  options: (string | ItemProps)[];
+  options: (string | ItemProps | SeparatorOption)[];
   title?: string;
   contentPosition?: "item-aligned" | "popper";
   value?: string;
@@ -31,6 +38,7 @@ export const Content: React.FC<ContentProps & { className?: string }> = (
 export type ItemProps = React.ComponentProps<typeof RadixSelect.Item> & {
   tooltip?: ReactNode;
 };
+
 export const Item: React.FC<ItemProps & { className?: string }> = (props) => (
   <RadixSelect.Item
     {...props}
@@ -51,7 +59,10 @@ export const Select: React.FC<SelectProps> = ({
   const maybeSelectedOption = useMemo(() => {
     if (typeof props.value === "undefined") return null;
     const selectOption = options.find(
-      (option) => typeof option !== "string" && option.value === props.value,
+      (option) =>
+        typeof option !== "string" &&
+        "value" in option &&
+        option.value === props.value,
     );
     if (!selectOption) return null;
     if (typeof selectOption === "string") return null;
@@ -59,7 +70,9 @@ export const Select: React.FC<SelectProps> = ({
   }, [props.value, options]);
   return (
     <Root {...props} onValueChange={onChange} size="1">
-      {maybeSelectedOption && maybeSelectedOption.tooltip ? (
+      {maybeSelectedOption &&
+      "tooltip" in maybeSelectedOption &&
+      maybeSelectedOption.tooltip ? (
         <HoverCard.Root openDelay={1000}>
           <HoverCard.Trigger>
             <Trigger />
@@ -83,12 +96,12 @@ export const Select: React.FC<SelectProps> = ({
               </Item>
             );
           }
-          if (option.type === 'separator') {
-            return <Separator key={option.key || `separator-${index}`} />;
+          if (isSeparator(option)) {
+            return <Separator key={option.key ?? `separator-${index}`} />;
           }
           if (option.tooltip) {
             return (
-              <Item key={option.key || `select-item-${index}-${option.value}`} {...option}>
+              <Item key={`select-item-${index}-${option.value}`} {...option}>
                 <HoverCard.Root>
                   <HoverCard.Trigger>
                     <div>
@@ -103,7 +116,7 @@ export const Select: React.FC<SelectProps> = ({
             );
           }
           return (
-            <Item key={option.key || `select-item-${index}-${option.value}`} {...option}>
+            <Item key={`select-item-${index}-${option.value}`} {...option}>
               {option.children ?? option.textValue ?? option.value}
             </Item>
           );

--- a/refact-agent/gui/src/components/Select/Select.tsx
+++ b/refact-agent/gui/src/components/Select/Select.tsx
@@ -83,9 +83,12 @@ export const Select: React.FC<SelectProps> = ({
               </Item>
             );
           }
+          if (option.type === 'separator') {
+            return <Separator key={option.key || `separator-${index}`} />;
+          }
           if (option.tooltip) {
             return (
-              <Item key={`select-item-${index}-${option.value}`} {...option}>
+              <Item key={option.key || `select-item-${index}-${option.value}`} {...option}>
                 <HoverCard.Root>
                   <HoverCard.Trigger>
                     <div>
@@ -100,7 +103,7 @@ export const Select: React.FC<SelectProps> = ({
             );
           }
           return (
-            <Item key={`select-item-${index}-${option.value}`} {...option}>
+            <Item key={option.key || `select-item-${index}-${option.value}`} {...option}>
               {option.children ?? option.textValue ?? option.value}
             </Item>
           );


### PR DESCRIPTION
- if there is only 1 default sys prompt - don’t show sys prompts selector  
-  Added “add model” option to models selector - which leads to Providers page -
- Also - removed duplicated selected model - we had one in textarea of chat form and another one selected in the bottom (chat controls)

![image](https://github.com/user-attachments/assets/1c80682b-8e3b-427e-a179-c58faf1d1e93)
