### PR TITLE
fix: stop button not showing while waiting for response.

### DIFF
--- a/refact-agent/gui/src/components/ChatContent/ChatContent.tsx
+++ b/refact-agent/gui/src/components/ChatContent/ChatContent.tsx
@@ -141,7 +141,7 @@ export const ChatContent: React.FC<ChatContentProps> = ({
       >
         <ScrollArea scrollbars="horizontal">
           <Flex align="start" gap="3" pb="2">
-            {isStreaming && (
+            {(isWaiting || isStreaming) && (
               <Button
                 // ml="auto"
                 color="red"


### PR DESCRIPTION
fixes: https://refact.fibery.io/Software_Development/Sprint-2025-05-05-579#Task/UI---Often-no-Stop-button-in-chat-1125

issue: Stop button doesn't show while waiting for a response.