### PR TITLE
feat: Add Claude 4 Opus and Sonnet model configurations

### DIFF
--- a/refact-agent/engine/src/known_models.json
+++ b/refact-agent/engine/src/known_models.json
@@ -210,6 +210,36 @@
                 "anthropic/claude-3-7-sonnet-20250219"
             ]
         },
+        "claude-opus-4-20250514": {
+            "n_ctx": 200000,
+            "scratchpad": "REPLACE_PASSTHROUGH",
+            "scratchpad_patch": {
+                "context_format": "chat",
+                "rag_ratio": 0.5
+            },
+            "experimental": true,
+            "tokenizer": "hf://Xenova/claude-tokenizer",
+            "similar_models": [
+                "claude-opus-4",
+                "anthropic/claude-opus-4-20250514",
+                "anthropic/claude-opus-4"
+            ]
+        },
+        "claude-sonnet-4-20250514": {
+            "n_ctx": 200000,
+            "scratchpad": "REPLACE_PASSTHROUGH",
+            "scratchpad_patch": {
+                "context_format": "chat",
+                "rag_ratio": 0.5
+            },
+            "experimental": true,
+            "tokenizer": "hf://Xenova/claude-tokenizer",
+            "similar_models": [
+                "claude-sonnet-4",
+                "anthropic/claude-sonnet-4-20250514",
+                "anthropic/claude-sonnet-4"
+            ]
+        },
         "groq-llama-3.1-8b": {
             "n_ctx": 128000,
             "scratchpad": "REPLACE_PASSTHROUGH",
@@ -434,7 +464,7 @@
             "similar_models": [
                 "openai/o3-mini"
             ]
-        },      
+        },
         "o4-mini": {
             "n_ctx": 200000,
             "supports_tools": true,
@@ -573,6 +603,38 @@
                 "anthropic/claude-3-7-sonnet",
                 "anthropic/claude-3.7-sonnet-latest",
                 "anthropic/claude-3-7-sonnet-latest"
+            ],
+            "tokenizer": "hf://Xenova/claude-tokenizer"
+        },
+        "claude-opus-4-20250514": {
+            "n_ctx": 200000,
+            "supports_tools": true,
+            "supports_multimodality": true,
+            "supports_clicks": true,
+            "supports_agent": true,
+            "supports_reasoning": "anthropic",
+            "supports_boost_reasoning": true,
+            "scratchpad": "PASSTHROUGH",
+            "similar_models": [
+                "claude-opus-4",
+                "anthropic/claude-opus-4-20250514",
+                "anthropic/claude-opus-4"
+            ],
+            "tokenizer": "hf://Xenova/claude-tokenizer"
+        },
+        "claude-sonnet-4-20250514": {
+            "n_ctx": 200000,
+            "supports_tools": true,
+            "supports_multimodality": true,
+            "supports_clicks": true,
+            "supports_agent": true,
+            "supports_reasoning": "anthropic",
+            "supports_boost_reasoning": true,
+            "scratchpad": "PASSTHROUGH",
+            "similar_models": [
+                "claude-sonnet-4",
+                "anthropic/claude-sonnet-4-20250514",
+                "anthropic/claude-sonnet-4"
             ],
             "tokenizer": "hf://Xenova/claude-tokenizer"
         },

--- a/refact-agent/engine/src/yaml_configs/default_providers/anthropic.yaml
+++ b/refact-agent/engine/src/yaml_configs/default_providers/anthropic.yaml
@@ -4,6 +4,22 @@ supports_completion: false
 api_key: sk-ant-...
 
 chat_models:
+  claude-opus-4-20250514:
+    n_ctx: 200000
+    supports_tools: true
+    supports_multimodality: true
+    supports_clicks: true
+    supports_agent: true
+    supports_reasoning: anthropic
+    tokenizer: hf://Xenova/claude-tokenizer
+  claude-sonnet-4-20250514:
+    n_ctx: 200000
+    supports_tools: true
+    supports_multimodality: true
+    supports_clicks: true
+    supports_agent: true
+    supports_reasoning: anthropic
+    tokenizer: hf://Xenova/claude-tokenizer
   claude-3-7-sonnet-latest:
     n_ctx: 200000
     supports_tools: true
@@ -14,6 +30,8 @@ chat_models:
     tokenizer: hf://Xenova/claude-tokenizer
 
 running_models:
+  - claude-opus-4-20250514
+  - claude-sonnet-4-20250514
   - claude-3-7-sonnet-latest
   - claude-3-5-sonnet-latest
   - claude-3-5-haiku-latest

--- a/refact-agent/engine/src/yaml_configs/default_providers/openrouter.yaml
+++ b/refact-agent/engine/src/yaml_configs/default_providers/openrouter.yaml
@@ -5,6 +5,8 @@ supports_completion: false
 api_key: "sk-or-..."
 
 running_models:
+  - anthropic/claude-opus-4-20250514
+  - anthropic/claude-sonnet-4-20250514
   - anthropic/claude-3.7-sonnet
   - openai/o3-mini
   - openai/gpt-4.1

--- a/refact-server/refact_known_models/passthrough.py
+++ b/refact-server/refact_known_models/passthrough.py
@@ -138,6 +138,30 @@ passthrough_mini_db = {
         "filter_caps": ["chat", "tools", "completion", "agent", "clicks", "reasoning"],
     },
 
+    # Claude 4 models
+    "claude-opus-4": {
+        "backend": "litellm",
+        "provider": "anthropic",
+        "tokenizer_path": "Xenova/claude-tokenizer",
+        "resolve_as": "claude-opus-4-20250514",
+        "T": 200_000,
+        "T_out": 128_000,
+        "pp1000t_prompt": 15_000,  # Estimated based on Claude 3 Opus pricing
+        "pp1000t_generated": 75_000,  # Estimated based on Claude 3 Opus pricing
+        "filter_caps": ["chat", "tools", "completion", "agent", "clicks", "reasoning"],
+    },
+    "claude-sonnet-4": {
+        "backend": "litellm",
+        "provider": "anthropic",
+        "tokenizer_path": "Xenova/claude-tokenizer",
+        "resolve_as": "claude-sonnet-4-20250514",
+        "T": 200_000,
+        "T_out": 128_000,
+        "pp1000t_prompt": 3_000,  # Estimated based on Claude 3.5 Sonnet pricing
+        "pp1000t_generated": 15_000,  # Estimated based on Claude 3.5 Sonnet pricing
+        "filter_caps": ["chat", "tools", "completion", "agent", "clicks", "reasoning"],
+    },
+
     # Groq models
     "groq-llama-3.1-8b": {
         "backend": "litellm",


### PR DESCRIPTION
Added support for new Claude 4 models with the following changes:

- Added Claude 4 Opus and Sonnet model definitions with 200k context window
- Updated Anthropic and OpenRouter provider configurations
- Added passthrough configurations with estimated pricing
- Configured model capabilities and tokenizer settings

Models added:
- claude-opus-4-20250514
- claude-sonnet-4-20250514

Both models are configured with full support for:
- Tools
- Multimodality
- Clicks
- Agent capabilities
- Anthropic reasoning

Changes include updates to:
- known_models.json
- yaml_configs/default_providers/anthropic.yaml
- yaml_configs/default_providers/openrouter.yaml
- refact_known_models/passthrough.py