### PR TITLE
Fix: visibility of group tree & passthrough if caps.metadata.features doesn't contain knowledge

### DIFF
--- a/refact-agent/gui/src/components/Sidebar/GroupTree/ConfirmGroupSelection/ConfirmGroupSelection.module.css
+++ b/refact-agent/gui/src/components/Sidebar/GroupTree/ConfirmGroupSelection/ConfirmGroupSelection.module.css
@@ -6,6 +6,7 @@
   margin-left: auto;
   margin-right: auto;
   background: var(--color-panel, #181a20);
+  min-height: fit-content;
 }
 
 .groupName {

--- a/refact-agent/gui/src/components/Sidebar/GroupTree/GroupTree.module.css
+++ b/refact-agent/gui/src/components/Sidebar/GroupTree/GroupTree.module.css
@@ -1,7 +1,11 @@
 /* Custom styles for the Tree component */
+div > .sidebarTree {
+  height: 100% !important;
+}
 .sidebarTree {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   width: 100%;
+  height: 100% !important;
   color: var(--gray-11);
 }
 

--- a/refact-agent/gui/src/components/Sidebar/GroupTree/GroupTree.tsx
+++ b/refact-agent/gui/src/components/Sidebar/GroupTree/GroupTree.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Select, Text } from "@radix-ui/themes";
+import { Flex, Heading, Select, Text } from "@radix-ui/themes";
 import React from "react";
 import { Tree } from "react-arborist";
 import { CustomTreeNode } from "./CustomTreeNode";
@@ -31,7 +31,6 @@ export const GroupTree: React.FC = () => {
     setGroupTreeData,
     onWorkspaceSelection,
     availableWorkspaces,
-    treeWidth,
     treeHeight,
   } = useGroupTree();
 
@@ -62,47 +61,43 @@ export const GroupTree: React.FC = () => {
           width="100%"
           height="100%"
           justify="between"
+          style={{ flex: 1, minHeight: 0 }} // <-- Add this line
         >
-          <Box width="100%">
-            <Flex direction="column" gap="1" mb="4">
-              <Heading as="h2" size="4">
-                Choose desired group
-              </Heading>
-              <Text size="3" color="gray">
-                Select a group to sync your knowledge with the cloud.
-              </Text>
-            </Flex>
-            <ScrollArea
-              ref={treeParentRef}
-              scrollbars="vertical"
-              style={{ maxHeight: 240 }}
+          <Flex direction="column" gap="1" mb="4">
+            <Heading as="h2" size="4">
+              Choose desired group
+            </Heading>
+            <Text size="3" color="gray">
+              Select a group to sync your knowledge with the cloud.
+            </Text>
+          </Flex>
+          <ScrollArea
+            ref={treeParentRef}
+            scrollbars="vertical"
+            style={{ flex: 1, minHeight: 0 }}
+          >
+            <Tree
+              data={filteredGroupTreeData}
+              rowHeight={40}
+              height={treeHeight}
+              width="100%"
+              indent={28}
+              onSelect={onGroupSelect}
+              openByDefault={false}
+              className={styles.sidebarTree}
+              selection={currentSelectedTeamsGroupNode?.treenodePath}
+              disableDrag
+              disableMultiSelection
+              disableEdit
+              disableDrop
+              idAccessor={"treenodePath"} // treenodePath seems to be more convenient for temporary tree nodes which later get removed
+              childrenAccessor={"treenodeChildren"}
             >
-              <Tree
-                data={filteredGroupTreeData}
-                rowHeight={40}
-                height={treeHeight}
-                width={treeWidth}
-                indent={28}
-                onSelect={onGroupSelect}
-                openByDefault={false}
-                className={styles.sidebarTree}
-                selection={currentSelectedTeamsGroupNode?.treenodePath}
-                disableDrag
-                disableMultiSelection
-                disableEdit
-                disableDrop
-                idAccessor={"treenodePath"} // treenodePath seems to be more convenient for temporary tree nodes which later get removed
-                childrenAccessor={"treenodeChildren"}
-              >
-                {(nodeProps) => (
-                  <CustomTreeNode
-                    updateTree={setGroupTreeData}
-                    {...nodeProps}
-                  />
-                )}
-              </Tree>
-            </ScrollArea>
-          </Box>
+              {(nodeProps) => (
+                <CustomTreeNode updateTree={setGroupTreeData} {...nodeProps} />
+              )}
+            </Tree>
+          </ScrollArea>
           {/* TODO: make it wrapped around AnimatePresence from motion */}
           {currentSelectedTeamsGroupNode !== null && (
             <ConfirmGroupSelection

--- a/refact-agent/gui/src/components/Sidebar/GroupTree/GroupTree.tsx
+++ b/refact-agent/gui/src/components/Sidebar/GroupTree/GroupTree.tsx
@@ -40,10 +40,13 @@ export const GroupTree: React.FC = () => {
         <Heading as="h2" size="4">
           Choose workspace
         </Heading>
-        <Text size="3" color="gray">
+        <Text size="3" color="gray" mb="1">
           Select a workspace associated to your team to continue.
         </Text>
-        <Select.Root onValueChange={onWorkspaceSelection}>
+        <Select.Root
+          onValueChange={onWorkspaceSelection}
+          disabled={availableWorkspaces.length === 0}
+        >
           <Select.Trigger placeholder="Choose workspace"></Select.Trigger>
           <Select.Content position="popper">
             {availableWorkspaces.map((workspace) => (
@@ -53,6 +56,14 @@ export const GroupTree: React.FC = () => {
             ))}
           </Select.Content>
         </Select.Root>
+        {availableWorkspaces.length === 0 && (
+          <Text size="2" mt="2">
+            No workspaces are currently associated with your account. Please
+            contact your Team Workspace administrator to request access. For
+            further assistance, please refer to the support or bug reporting
+            channels.
+          </Text>
+        )}
       </Flex>
       {currentTeamsWorkspace && filteredGroupTreeData.length > 0 && (
         <Flex

--- a/refact-agent/gui/src/components/Sidebar/GroupTree/useGroupTree.ts
+++ b/refact-agent/gui/src/components/Sidebar/GroupTree/useGroupTree.ts
@@ -124,18 +124,15 @@ export function useGroupTree() {
   const [treeHeight, setTreeHeight] = useState<number>(
     treeParentRef.current?.clientHeight ?? 0,
   );
-  const [treeWidth, setTreeWidth] = useState<number>(
-    treeParentRef.current?.clientHeight ?? 0,
-  );
 
   const calculateAndSetSpace = useCallback(() => {
     if (!treeParentRef.current) {
       return;
     }
-
     setTreeHeight(treeParentRef.current.clientHeight);
-    setTreeWidth(treeParentRef.current.clientWidth);
-  }, [treeParentRef]);
+    // NOTE: this is a hack to avoid the tree being with 0 width/height even when data appears
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [treeParentRef, filteredGroupTreeData]);
 
   useResizeObserver(treeParentRef.current, calculateAndSetSpace);
 
@@ -213,7 +210,6 @@ export function useGroupTree() {
     currentTeamsWorkspace,
     currentSelectedTeamsGroupNode,
     // Dimensions
-    treeWidth,
     treeHeight,
     // Actions
     onGroupSelect,

--- a/refact-agent/gui/src/components/Sidebar/Sidebar.tsx
+++ b/refact-agent/gui/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Box, Flex, Spinner } from "@radix-ui/themes";
 import { ChatHistory, type ChatHistoryProps } from "../ChatHistory";
-import { useAppSelector, useAppDispatch } from "../../hooks";
+import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
 import {
   ChatHistoryItem,
   deleteChatById,
@@ -41,6 +41,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
     devModeChecks: { stabilityCheck: "never" },
   });
 
+  const { data: capsData } = useCapsForToolUse();
+
   const onDeleteHistoryItem = useCallback(
     (id: string) => dispatch(deleteChatById(id)),
     [dispatch],
@@ -54,6 +56,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
     [dispatch],
   );
 
+  const shouldGroupTreeBeVisible = useMemo(() => {
+    return (
+      capsData?.metadata?.features?.includes("knowledge") === true &&
+      !maybeSelectedTeamsGroup
+    );
+  }, [maybeSelectedTeamsGroup, capsData?.metadata?.features]);
+
   return (
     <Flex style={style}>
       <FeatureMenu />
@@ -63,7 +72,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
         </Box>
       </Flex>
 
-      {maybeSelectedTeamsGroup ? (
+      {!shouldGroupTreeBeVisible ? (
         <ChatHistory
           history={history}
           onHistoryItemClick={onHistoryItemClick}

--- a/refact-agent/gui/src/components/Toolbar/Dropdown.tsx
+++ b/refact-agent/gui/src/components/Toolbar/Dropdown.tsx
@@ -8,6 +8,7 @@ import {
   useAppDispatch,
   useStartPollingForUser,
   useEventsBusForIDE,
+  useCapsForToolUse,
 } from "../../hooks";
 import { useOpenUrl } from "../../hooks/useOpenUrl";
 import {
@@ -83,6 +84,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   const coinBalance = useCoinBallance();
   const logout = useLogout();
   const { startPollingForUser } = useStartPollingForUser();
+  const { data: capsData } = useCapsForToolUse();
 
   const bugUrl = linkForBugReports(host);
   const discordUrl = "https://www.smallcloud.ai/discord";
@@ -257,12 +259,14 @@ export const Dropdown: React.FC<DropdownProps> = ({
           <GearIcon /> Configure Providers
         </DropdownMenu.Item>
 
-        <DropdownMenu.Item
-          // TODO: get real URL from cloud inference
-          onSelect={() => openUrl("https://test-teams.smallcloud.ai/")}
-        >
-          Manage Knowledge
-        </DropdownMenu.Item>
+        {capsData?.metadata?.features?.includes("knowledge") && (
+          <DropdownMenu.Item
+            // TODO: get real URL from cloud inference
+            onSelect={() => openUrl("https://test-teams.smallcloud.ai/")}
+          >
+            Manage Knowledge
+          </DropdownMenu.Item>
+        )}
 
         <DropdownMenu.Item onSelect={() => handleNavigation("settings")}>
           {refactProductType} Settings

--- a/refact-agent/gui/src/services/refact/caps.ts
+++ b/refact-agent/gui/src/services/refact/caps.ts
@@ -67,6 +67,7 @@ function isCapCost(json: unknown): json is CapCost {
 }
 type CapsMetadata = {
   pricing?: Record<string, CapCost>;
+  features?: string[];
 };
 
 function isCapsMetadata(json: unknown): json is CapsMetadata {


### PR DESCRIPTION
Fixes this one:
https://refact.fibery.io/Software_Development/Task/Bug---Group-tree-is-not-being-rendered-from-time-to-time-1168
https://refact.fibery.io/Software_Development/Task/Bug---select-workspace-only-if-caps.metadata-supports-it-1167