### PR TITLE
Prevent send fix

### DIFF
--- a/refact-agent/gui/src/components/ChatContent/ToolsContent.tsx
+++ b/refact-agent/gui/src/components/ChatContent/ToolsContent.tsx
@@ -23,6 +23,8 @@ import { Chevron } from "../Collapsible";
 import { Reveal } from "../Reveal";
 import { useAppSelector, useHideScroll } from "../../hooks";
 import {
+  selectIsStreaming,
+  selectIsWaiting,
   selectManyDiffMessageByIds,
   selectManyToolResultsByIds,
   selectToolResultById,
@@ -131,6 +133,8 @@ export const SingleModelToolContent: React.FC<{
   const [open, setOpen] = React.useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const handleHide = useHideScroll(ref);
+  const isStreaming = useAppSelector(selectIsStreaming);
+  const isWaiting = useAppSelector(selectIsWaiting);
 
   const toolCallsId = useMemo(() => {
     const ids = toolCalls.reduce<string[]>((acc, toolCall) => {
@@ -146,6 +150,11 @@ export const SingleModelToolContent: React.FC<{
   const allResolved = useMemo(() => {
     return results.length + diffs.length === toolCallsId.length;
   }, [diffs.length, results.length, toolCallsId.length]);
+
+  const busy = useMemo(() => {
+    if (allResolved) return false;
+    return isStreaming || isWaiting;
+  }, [allResolved, isStreaming, isWaiting]);
 
   const handleClose = useCallback(() => {
     handleHide();
@@ -202,7 +211,7 @@ export const SingleModelToolContent: React.FC<{
             subchat={subchat}
             open={open}
             onClick={() => setOpen((prev) => !prev)}
-            waiting={!allResolved}
+            waiting={busy}
           />
         </Collapsible.Trigger>
         <Collapsible.Content>
@@ -328,6 +337,8 @@ const MultiModalToolContent: React.FC<{
   const [open, setOpen] = React.useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const handleHide = useHideScroll(ref);
+  const isStreaming = useAppSelector(selectIsStreaming);
+  const isWaiting = useAppSelector(selectIsWaiting);
   const ids = useMemo(() => {
     return toolCalls.reduce<string[]>((acc, cur) => {
       if (typeof cur === "string") return [...acc, cur];
@@ -379,6 +390,11 @@ const MultiModalToolContent: React.FC<{
     );
   }, [toolCalls, toolResults, diffs]);
 
+  const busy = useMemo(() => {
+    if (hasResults) return false;
+    return isStreaming || isWaiting;
+  }, [hasResults, isStreaming, isWaiting]);
+
   return (
     <Container>
       <Collapsible.Root open={open} onOpenChange={setOpen}>
@@ -388,7 +404,7 @@ const MultiModalToolContent: React.FC<{
             open={open}
             onClick={() => setOpen((prev) => !prev)}
             ref={ref}
-            waiting={!hasResults}
+            waiting={busy}
           />
         </Collapsible.Trigger>
         <Collapsible.Content>

--- a/refact-agent/gui/src/components/ChatContent/ToolsContent.tsx
+++ b/refact-agent/gui/src/components/ChatContent/ToolsContent.tsx
@@ -541,7 +541,7 @@ const ToolUsageSummary = forwardRef<HTMLDivElement, ToolUsageSummaryProps>(
             })}
             {subchat && (
               <Flex ml="4">
-                <Spinner />
+                {waiting && <Spinner />}
                 <Text weight="light" size="1" ml="4px">
                   {subchat}
                 </Text>

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -50,14 +50,11 @@ import { getPauseReasonsWithPauseStatus } from "../../features/ToolConfirmation/
 import { AttachImagesButton, FileList } from "../Dropzone";
 import { useAttachedImages } from "../../hooks/useAttachedImages";
 import {
-  enableSend,
   selectChatError,
-  selectChatId,
   selectIsStreaming,
   selectIsWaiting,
   selectLastSentCompression,
   selectMessages,
-  selectPreventSend,
   selectThreadToolUse,
   selectToolUse,
 } from "../../features/Chat";
@@ -96,10 +93,8 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const isOnline = useIsOnline();
   const { retry } = useSendChatRequest();
 
-  const chatId = useAppSelector(selectChatId);
   const threadToolUse = useAppSelector(selectThreadToolUse);
   const messages = useAppSelector(selectMessages);
-  const preventSend = useAppSelector(selectPreventSend);
   const lastSentCompression = useAppSelector(selectLastSentCompression);
   const { compressChat, compressChatRequest, isCompressing } =
     useCompressChat();
@@ -136,15 +131,8 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     //   return false;
     // if (arePromptTokensBiggerThanContext) return true;
     if (messages.length === 0) return false;
-    return isWaiting || isStreaming || !isOnline || preventSend;
-  }, [
-    allDisabled,
-    messages.length,
-    isWaiting,
-    isStreaming,
-    isOnline,
-    preventSend,
-  ]);
+    return isWaiting || isStreaming || !isOnline;
+  }, [allDisabled, messages.length, isWaiting, isStreaming, isOnline]);
 
   const isModelSelectVisible = useMemo(() => messages.length < 1, [messages]);
 
@@ -278,27 +266,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
       error_message: "",
     });
   }, [dispatch, sendTelemetryEvent]);
-
-  useEffect(() => {
-    // this use effect is required to reset preventSend when chat was restored
-    if (
-      preventSend &&
-      !unCalledTools &&
-      !isStreaming &&
-      !isWaiting &&
-      isOnline
-    ) {
-      dispatch(enableSend({ id: chatId }));
-    }
-  }, [
-    dispatch,
-    isOnline,
-    isWaiting,
-    isStreaming,
-    preventSend,
-    chatId,
-    unCalledTools,
-  ]);
 
   useEffect(() => {
     if (isSendImmediately && !isWaiting && !isStreaming) {

--- a/refact-agent/gui/src/features/Chat/Chat.tsx
+++ b/refact-agent/gui/src/features/Chat/Chat.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Config } from "../Config/configSlice";
 import { Chat as ChatComponent } from "../../components/Chat";
 import { useAppSelector } from "../../hooks";
-import { selectMessages } from "./Thread";
+import { selectHasUncalledTools, selectMessages } from "./Thread";
 
 export type ChatProps = {
   host: Config["host"];
@@ -17,8 +17,6 @@ export const Chat: React.FC<ChatProps> = ({
   host,
   tabbed,
 }) => {
-  const messages = useAppSelector(selectMessages);
-
   const sendToSideBar = () => {
     // TODO:
   };
@@ -26,16 +24,7 @@ export const Chat: React.FC<ChatProps> = ({
   const maybeSendToSideBar =
     host === "vscode" && tabbed ? sendToSideBar : undefined;
 
-  // can be a selector
-  const unCalledTools = React.useMemo(() => {
-    if (messages.length === 0) return false;
-    const last = messages[messages.length - 1];
-    if (last.role !== "assistant") return false;
-    const maybeTools = last.tool_calls;
-    if (maybeTools && maybeTools.length > 0) return true;
-    return false;
-  }, [messages]);
-
+  const unCalledTools = useAppSelector(selectHasUncalledTools);
   return (
     <ChatComponent
       style={style}

--- a/refact-agent/gui/src/features/Chat/Chat.tsx
+++ b/refact-agent/gui/src/features/Chat/Chat.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Config } from "../Config/configSlice";
 import { Chat as ChatComponent } from "../../components/Chat";
 import { useAppSelector } from "../../hooks";
-import { selectHasUncalledTools, selectMessages } from "./Thread";
+import { selectHasUncalledTools } from "./Thread";
 
 export type ChatProps = {
   host: Config["host"];

--- a/refact-agent/gui/src/features/Chat/Thread/reducer.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/reducer.ts
@@ -241,7 +241,6 @@ export const chatReducer = createReducer(initialState, (builder) => {
     state.streaming = false;
     state.waiting_for_response = false;
     state.thread.read = true;
-    state.prevent_send = false;
   });
 
   builder.addCase(setAutomaticPatch, (state, action) => {

--- a/refact-agent/gui/src/features/Chat/Thread/selectors.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/selectors.ts
@@ -2,10 +2,12 @@ import { RootState } from "../../../app/store";
 import { createSelector } from "@reduxjs/toolkit";
 import {
   CompressionStrength,
+  isAssistantMessage,
   isDiffMessage,
   isToolMessage,
   isUserMessage,
 } from "../../../services/refact/types";
+import { takeFromLast } from "../../../utils/takeFromLast";
 
 export const selectThread = (state: RootState) => state.chat.thread;
 export const selectThreadTitle = (state: RootState) => state.chat.thread.title;
@@ -113,5 +115,35 @@ export const selectLastSentCompression = createSelector(
     );
 
     return lastCompression;
+  },
+);
+
+export const selectHasUncalledTools = createSelector(
+  selectMessages,
+  (messages) => {
+    if (messages.length === 0) return false;
+    const tailMessages = takeFromLast(messages, isUserMessage);
+
+    const toolCalls = tailMessages.reduce<string[]>((acc, cur) => {
+      if (!isAssistantMessage(cur)) return acc;
+      if (!cur.tool_calls || cur.tool_calls.length === 0) return acc;
+      const curToolCallIds = cur.tool_calls
+        .map((toolCall) => toolCall.id)
+        .filter((id) => id !== undefined);
+
+      return [...acc, ...curToolCallIds];
+    }, []);
+
+    if (toolCalls.length === 0) return false;
+
+    const toolMessages = tailMessages
+      .filter(isToolMessage)
+      .map((toolMessage) => toolMessage.content.tool_call_id);
+
+    const hasUnsentTools = toolCalls.some(
+      (toolCallId) => !toolMessages.includes(toolCallId),
+    );
+
+    return hasUnsentTools;
   },
 );


### PR DESCRIPTION
Fixes the stop button,
(prevent send was being reset when `doneStreaming` causing issues)
refactored `autoSend` so the dependencies for `useEffect` change less often (causing the hook to trigger).

How to test..

Ask a questoin like `call tree` wait until the tool call is on screen and press `stop`... change the timing a few times and it should stop and stay stoped. 