### PR TITLE
Fix: Active Teams Group state management

### DIFF
--- a/refact-agent/gui/src/__fixtures__/msw.ts
+++ b/refact-agent/gui/src/__fixtures__/msw.ts
@@ -27,6 +27,16 @@ export const goodCaps: HttpHandler = http.get(
   },
 );
 
+export const goodCapsWithKnowledgeFeature: HttpHandler = http.get(
+  "http://127.0.0.1:8001/v1/caps",
+  () => {
+    return HttpResponse.json({
+      ...STUB_CAPS_RESPONSE,
+      metadata: { features: ["knowledge"] },
+    });
+  },
+);
+
 export const emptyCaps: HttpHandler = http.get(
   `http://127.0.0.1:8001/v1/caps`,
   () => {

--- a/refact-agent/gui/src/__tests__/StartNewChat.test.tsx
+++ b/refact-agent/gui/src/__tests__/StartNewChat.test.tsx
@@ -12,6 +12,7 @@ import {
   chatLinks,
   telemetryChat,
   telemetryNetwork,
+  goodCapsWithKnowledgeFeature,
 } from "../utils/mockServer";
 import { InnerApp } from "../features/App";
 import { stubResizeObserver } from "../utils/test-utils";
@@ -47,6 +48,52 @@ describe("Start a new chat", () => {
         pages: [{ name: "history" }],
         teams: {
           group: { id: "123", name: "test" },
+        },
+        config: {
+          apiKey: "test",
+          lspPort: 8001,
+          themeProps: {},
+          host: "vscode",
+          addressURL: "Refact",
+        },
+      },
+    });
+    const btn = app.getByText("New chat");
+    await user.click(btn);
+
+    const textarea = app.container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+  });
+  test("open chat with New Chat Button when knowledge feature is available", async () => {
+    server.use(goodCapsWithKnowledgeFeature);
+
+    const { user, ...app } = render(<InnerApp />, {
+      preloadedState: {
+        pages: [{ name: "history" }],
+        teams: {
+          group: { id: "123", name: "test" },
+        },
+        config: {
+          apiKey: "test",
+          lspPort: 8001,
+          themeProps: {},
+          host: "vscode",
+          addressURL: "Refact",
+        },
+      },
+    });
+    const btn = app.getByText("New chat");
+    await user.click(btn);
+
+    const textarea = app.container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+  });
+  test("open chat with New Chat Button when knowledge feature is NOT available", async () => {
+    const { user, ...app } = render(<InnerApp />, {
+      preloadedState: {
+        pages: [{ name: "history" }],
+        teams: {
+          group: null,
         },
         config: {
           apiKey: "test",

--- a/refact-agent/gui/src/components/Sidebar/Sidebar.tsx
+++ b/refact-agent/gui/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { Box, Flex, Spinner } from "@radix-ui/themes";
 import { ChatHistory, type ChatHistoryProps } from "../ChatHistory";
-import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
+import { useAppSelector, useAppDispatch } from "../../hooks";
 import {
   ChatHistoryItem,
   deleteChatById,
@@ -9,13 +9,13 @@ import {
 import { push } from "../../features/Pages/pagesSlice";
 import { restoreChat } from "../../features/Chat/Thread";
 import { FeatureMenu } from "../../features/Config/FeatureMenu";
-import { selectActiveGroup } from "../../features/Teams";
 import { GroupTree } from "./GroupTree/";
 import { ErrorCallout } from "../Callout";
 import { getErrorMessage, clearError } from "../../features/Errors/errorsSlice";
 import classNames from "classnames";
 import { selectHost } from "../../features/Config/configSlice";
 import styles from "./Sidebar.module.css";
+import { useActiveTeamsGroup } from "../../hooks/useActiveTeamsGroup";
 
 export type SidebarProps = {
   takingNotes: boolean;
@@ -34,14 +34,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
   // TODO: these can be lowered.
   const dispatch = useAppDispatch();
   const globalError = useAppSelector(getErrorMessage);
-  const maybeSelectedTeamsGroup = useAppSelector(selectActiveGroup);
   const currentHost = useAppSelector(selectHost);
   const history = useAppSelector((app) => app.history, {
     // TODO: selector issue here
     devModeChecks: { stabilityCheck: "never" },
   });
 
-  const { data: capsData } = useCapsForToolUse();
+  const { groupSelectionEnabled } = useActiveTeamsGroup();
 
   const onDeleteHistoryItem = useCallback(
     (id: string) => dispatch(deleteChatById(id)),
@@ -56,13 +55,6 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
     [dispatch],
   );
 
-  const shouldGroupTreeBeVisible = useMemo(() => {
-    return (
-      capsData?.metadata?.features?.includes("knowledge") === true &&
-      !maybeSelectedTeamsGroup
-    );
-  }, [maybeSelectedTeamsGroup, capsData?.metadata?.features]);
-
   return (
     <Flex style={style}>
       <FeatureMenu />
@@ -72,7 +64,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ takingNotes, style }) => {
         </Box>
       </Flex>
 
-      {!shouldGroupTreeBeVisible ? (
+      {!groupSelectionEnabled ? (
         <ChatHistory
           history={history}
           onHistoryItemClick={onHistoryItemClick}

--- a/refact-agent/gui/src/components/Toolbar/Dropdown.tsx
+++ b/refact-agent/gui/src/components/Toolbar/Dropdown.tsx
@@ -8,7 +8,6 @@ import {
   useAppDispatch,
   useStartPollingForUser,
   useEventsBusForIDE,
-  useCapsForToolUse,
 } from "../../hooks";
 import { useOpenUrl } from "../../hooks/useOpenUrl";
 import {
@@ -33,6 +32,7 @@ import { useCoinBallance } from "../../hooks/useCoinBalance";
 import { isUserWithLoginMessage } from "../../services/smallcloud/types";
 import { resetActiveGroup, selectActiveGroup } from "../../features/Teams";
 import { popBackTo } from "../../features/Pages/pagesSlice";
+import { useActiveTeamsGroup } from "../../hooks/useActiveTeamsGroup";
 
 export type DropdownNavigationOptions =
   | "fim"
@@ -84,7 +84,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
   const coinBalance = useCoinBallance();
   const logout = useLogout();
   const { startPollingForUser } = useStartPollingForUser();
-  const { data: capsData } = useCapsForToolUse();
+
+  const { isKnowledgeFeatureAvailable } = useActiveTeamsGroup();
 
   const bugUrl = linkForBugReports(host);
   const discordUrl = "https://www.smallcloud.ai/discord";
@@ -259,7 +260,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
           <GearIcon /> Configure Providers
         </DropdownMenu.Item>
 
-        {capsData?.metadata?.features?.includes("knowledge") && (
+        {isKnowledgeFeatureAvailable && (
           <DropdownMenu.Item
             // TODO: get real URL from cloud inference
             onSelect={() => openUrl("https://test-teams.smallcloud.ai/")}
@@ -319,12 +320,14 @@ export const Dropdown: React.FC<DropdownProps> = ({
           Clear Chat History
         </DropdownMenu.Item>
 
-        <DropdownMenu.Item
-          onSelect={handleActiveGroupCleanUp}
-          disabled={activeGroup === null}
-        >
-          Unselect Active Group
-        </DropdownMenu.Item>
+        {isKnowledgeFeatureAvailable && (
+          <DropdownMenu.Item
+            onSelect={handleActiveGroupCleanUp}
+            disabled={activeGroup === null}
+          >
+            Unselect Active Group
+          </DropdownMenu.Item>
+        )}
 
         <DropdownMenu.Item
           onSelect={(event) => {

--- a/refact-agent/gui/src/components/Toolbar/Toolbar.tsx
+++ b/refact-agent/gui/src/components/Toolbar/Toolbar.tsx
@@ -44,7 +44,7 @@ import { clearPauseReasonsAndHandleToolsStatus } from "../../features/ToolConfir
 import { telemetryApi } from "../../services/refact/telemetry";
 
 import styles from "./Toolbar.module.css";
-import { selectActiveGroup } from "../../features/Teams";
+import { useActiveTeamsGroup } from "../../hooks/useActiveTeamsGroup";
 
 export type DashboardTab = {
   type: "dashboard";
@@ -86,7 +86,7 @@ export const Toolbar = ({ activeTab }: ToolbarProps) => {
   const isStreaming = useAppSelector((app) => app.chat.streaming);
   const { isTitleGenerated, id: chatId } = useAppSelector(selectThread);
   const cache = useAppSelector((app) => app.chat.cache);
-  const activeGroup = useAppSelector(selectActiveGroup);
+  const { newChatEnabled } = useActiveTeamsGroup();
 
   const { openSettings, openHotKeys } = useEventsBusForIDE();
 
@@ -381,7 +381,7 @@ export const Toolbar = ({ activeTab }: ToolbarProps) => {
           variant="outline"
           ref={(x) => refs.setNewChat(x)}
           onClick={onCreateNewChat}
-          disabled={activeGroup === null}
+          disabled={!newChatEnabled}
         >
           <PlusIcon />
           <Text>New chat</Text>

--- a/refact-agent/gui/src/hooks/useActiveTeamsGroup.ts
+++ b/refact-agent/gui/src/hooks/useActiveTeamsGroup.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { useAppSelector } from "./useAppSelector";
+import { useCapsForToolUse } from "./useCapsForToolUse";
+import { selectActiveGroup } from "../features/Teams";
+
+/**
+ * Use this hook to get states related to caps supported features alongside the current active teams group.
+ **/
+export function useActiveTeamsGroup() {
+  const { data: capsData } = useCapsForToolUse();
+  const maybeActiveTeamsGroup = useAppSelector(selectActiveGroup);
+
+  const isKnowledgeFeatureAvailable = useMemo(() => {
+    return capsData?.metadata?.features?.includes("knowledge") === true;
+  }, [capsData?.metadata?.features]);
+
+  const groupSelectionEnabled = useMemo(() => {
+    return isKnowledgeFeatureAvailable && !maybeActiveTeamsGroup;
+  }, [maybeActiveTeamsGroup, isKnowledgeFeatureAvailable]);
+
+  const newChatEnabled = useMemo(() => {
+    if (isKnowledgeFeatureAvailable) {
+      return !!maybeActiveTeamsGroup;
+    }
+
+    return true;
+  }, [maybeActiveTeamsGroup, isKnowledgeFeatureAvailable]);
+
+  return {
+    groupSelectionEnabled,
+    isKnowledgeFeatureAvailable,
+    newChatEnabled,
+  };
+}


### PR DESCRIPTION
Fixes these:
https://refact.fibery.io/Software_Development/Task/bug---Creating-new-chat-button-is-disabled-for-Free-Pro-users-1170