### PR TITLE
Fix: Container Running with Dangerous Root User Permissions in refact-agent/engine/docker/chrome/Dockerfile

### DIFF
--- a/refact-agent/engine/docker/chrome/Dockerfile
+++ b/refact-agent/engine/docker/chrome/Dockerfile
@@ -1,5 +1,16 @@
 FROM debian:bookworm
 
+# Create a non-root user for security
+RUN groupadd -r chromeuser && useradd -r -g chromeuser -s /bin/false chromeuser
+
+# Create a non-root user for security
+RUN groupadd -r chromeuser && useradd -r -g chromeuser -u 1001 chromeuser
+
+
+# Create a non-root user for security
+RUN groupadd -r chromeuser && useradd -r -g chromeuser -u 1001 chromeuser
+
+
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
@@ -26,4 +37,13 @@ COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+
+# Switch to non-root user
+USER chromeuser
+
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+# Switch to non-root user
+USER chromeuser
+
+# Switch to non-root user
+USER chromeuser


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
- **Rule ID:** dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
- **Severity:** MEDIUM
- **File:** refact-agent/engine/docker/chrome/Dockerfile
- **Lines Affected:** 29 - 29

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `refact-agent/engine/docker/chrome/Dockerfile` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.