### PR TITLE
Security Patch for API key in URL

### DIFF
--- a/refact-agent/gui/src/features/Login/LoginPage.tsx
+++ b/refact-agent/gui/src/features/Login/LoginPage.tsx
@@ -162,6 +162,7 @@ export const LoginPage: React.FC = () => {
               {/** TODO: handle these changes */}
               <form
                 onSubmit={(event) => {
+                  event.preventDefault();
                   const formData = new FormData(event.currentTarget);
                   const endpoint = formData.get("endpoint");
                   const apiKey = formData.get("api-key");


### PR DESCRIPTION

### This patch removes the circumnavigation by stopping the browser from automatically grabbing the form key and sticking it in the URL.

# The Issue
There's a lot of really nice security practices within the web gui. However, a missing PreventDefault() function in the Login Form is causing the API key and endpoint to be leaked into the URL, adding a circumnavigation to using just the Authorization header. 

<img width="440" height="41" alt="Screenshot 2025-08-15 at 12 43 06 PM" src="https://github.com/user-attachments/assets/dfa35b30-be59-4320-b2c7-45809ee156e1" />

# The fix
The newly added PreventDefault() in the login form stops the API key from leaking into the URL, which may propagate to Browser histories and server logs with the API key attached. Here's how it looks now:

On Chrome:
<img width="440" height="42" alt="Screenshot 2025-08-15 at 12 44 04 PM" src="https://github.com/user-attachments/assets/703e3781-015a-4206-9a95-3a921f9ca165" />

On Safari:
<img width="265" height="40" alt="Screenshot 2025-08-15 at 12 52 16 PM" src="https://github.com/user-attachments/assets/bac2f1ef-8b5a-4a81-adc8-ab39a2b9639c" />

