### PR TITLE
fix: improve usage counter layout and prevent text overlap

### DIFF
--- a/refact-agent/gui/src/components/ChatContent/AssistantInput.tsx
+++ b/refact-agent/gui/src/components/ChatContent/AssistantInput.tsx
@@ -104,7 +104,7 @@ export const AssistantInput: React.FC<ChatInputProps> = ({
         />
       )}
       {message && (
-        <Box py="4">
+        <Box py="4" style={{ paddingRight: "50px" }}>
           <Markdown canHaveInteractiveElements={true} onCopyClick={handleCopy}>
             {message}
           </Markdown>

--- a/refact-agent/gui/src/components/ChatContent/MessageUsageInfo.tsx
+++ b/refact-agent/gui/src/components/ChatContent/MessageUsageInfo.tsx
@@ -92,22 +92,9 @@ export const MessageUsageInfo: React.FC<MessageUsageInfoProps> = ({
               cursor: "pointer",
             }}
           >
-            <Flex align="center" gap="2">
-              {totalCoins > 0 && (
-                <Flex align="center" gap="1">
-                  <Text size="1">{Math.round(totalCoins)}</Text>
-                  <Coin width="10px" height="10px" />
-                </Flex>
-              )}
-              {contextTokens > 0 && (
-                <Text
-                  size="1"
-                  color="gray"
-                  title="Context tokens for this message"
-                >
-                  ctx: {formatNumberToFixed(contextTokens)}
-                </Text>
-              )}
+            <Flex align="center" gap="1">
+              <Text size="1">{Math.round(totalCoins)}</Text>
+              <Coin width="10px" height="10px" />
             </Flex>
           </Card>
         </HoverCard.Trigger>

--- a/refact-agent/gui/src/components/ChatContent/ReasoningContent/ReasoningContent.tsx
+++ b/refact-agent/gui/src/components/ChatContent/ReasoningContent/ReasoningContent.tsx
@@ -15,7 +15,7 @@ export const ReasoningContent: React.FC<ReasoningContentProps> = ({
   onCopyClick,
 }) => {
   return (
-    <Box py="4">
+    <Box py="4" style={{ paddingRight: "50px" }}>
       <Flex direction="column" gap="2" className={styles.reasoningCallout}>
         <Heading as="h3" color="gray" size="2">
           Model Reasoning

--- a/refact-agent/gui/src/components/UsageCounter/UsageCounter.tsx
+++ b/refact-agent/gui/src/components/UsageCounter/UsageCounter.tsx
@@ -303,43 +303,52 @@ const DefaultHoverTriggerContent: React.FC<{
   currentSessionTokens: number;
   compressionStrength?: CompressionStrength | null;
   totalCoins?: number;
-  cacheReadTokens?: number;
-  cacheWriteTokens?: number;
 }> = ({
   inputTokens,
   outputTokens,
   currentSessionTokens,
   compressionStrength,
   totalCoins,
-  cacheReadTokens,
-  cacheWriteTokens,
 }) => {
   const compressionLabel = formatCompressionStage(compressionStrength);
+  const hasCoinsOrContext =
+    (totalCoins !== undefined && totalCoins > 0) || currentSessionTokens !== 0;
+  const hasInputOutput = inputTokens !== 0 || outputTokens !== 0;
 
   return (
-    <>
-      {totalCoins !== undefined && totalCoins > 0 && (
-        <Flex align="center" gap="1" title="Total coins spent">
-          <Text size="1">{Math.round(totalCoins)}</Text>
-          <Coin width="12px" height="12px" />
+    <Flex direction="column" align="end" gap="1">
+      {hasCoinsOrContext && (
+        <Flex align="center" gap="2">
+          {totalCoins !== undefined && totalCoins > 0 && (
+            <Flex align="center" gap="1" title="Total coins spent">
+              <Text size="1">{Math.round(totalCoins)}</Text>
+              <Coin width="12px" height="12px" />
+            </Flex>
+          )}
+          {currentSessionTokens !== 0 && (
+            <Text size="1" color="gray" title="Current context window usage">
+              ctx: {formatNumberToFixed(currentSessionTokens)}
+            </Text>
+          )}
+          {compressionLabel && (
+            <Text
+              size="1"
+              color={
+                compressionStrength === "high"
+                  ? "red"
+                  : compressionStrength === "medium"
+                    ? "yellow"
+                    : "gray"
+              }
+              title="Compression stage"
+            >
+              ⚡{compressionLabel}
+            </Text>
+          )}
         </Flex>
       )}
-      {currentSessionTokens !== 0 && (
-        <Flex align="center" gap="1">
-          <Text size="1" color="gray" title="Current context window usage">
-            ctx: {formatNumberToFixed(currentSessionTokens)}
-          </Text>
-        </Flex>
-      )}
-      {(inputTokens !== 0 || outputTokens !== 0) && (
-        <Flex
-          align="center"
-          gap="1"
-          title="Total tokens: input ↑ / output ↓ / cache read 📖 / cache write ✏️"
-        >
-          <Text size="1" color="gray">
-            Σ
-          </Text>
+      {hasInputOutput && (
+        <Flex align="center" gap="2" title="Total tokens: input ↑ / output ↓">
           {inputTokens !== 0 && (
             <Flex align="center">
               <ArrowUpIcon width="12" height="12" />
@@ -352,38 +361,9 @@ const DefaultHoverTriggerContent: React.FC<{
               <Text size="1">{formatNumberToFixed(outputTokens)}</Text>
             </Flex>
           )}
-          {cacheReadTokens !== undefined && cacheReadTokens > 0 && (
-            <Flex align="center" gap="1" title="Cache read tokens">
-              <Text size="1">📖</Text>
-              <Text size="1">{formatNumberToFixed(cacheReadTokens)}</Text>
-            </Flex>
-          )}
-          {cacheWriteTokens !== undefined && cacheWriteTokens > 0 && (
-            <Flex align="center" gap="1" title="Cache write tokens">
-              <Text size="1">✏️</Text>
-              <Text size="1">{formatNumberToFixed(cacheWriteTokens)}</Text>
-            </Flex>
-          )}
         </Flex>
       )}
-      {compressionLabel && (
-        <Flex align="center">
-          <Text
-            size="1"
-            color={
-              compressionStrength === "high"
-                ? "red"
-                : compressionStrength === "medium"
-                  ? "yellow"
-                  : "gray"
-            }
-            title="Compression stage"
-          >
-            ⚡{compressionLabel}
-          </Text>
-        </Flex>
-      )}
-    </>
+    </Flex>
   );
 };
 
@@ -427,20 +407,6 @@ export const UsageCounter: React.FC<UsageCounterProps> = ({
       meteringTokens.metering_prompt_tokens_n
     );
   }, [meteringTokens]);
-
-  const cacheReadTokens = useMemo(() => {
-    if (meteringTokens !== null) {
-      return meteringTokens.metering_cache_read_tokens_n;
-    }
-    return currentThreadUsage?.cache_read_input_tokens;
-  }, [meteringTokens, currentThreadUsage]);
-
-  const cacheWriteTokens = useMemo(() => {
-    if (meteringTokens !== null) {
-      return meteringTokens.metering_cache_creation_tokens_n;
-    }
-    return currentThreadUsage?.cache_creation_input_tokens;
-  }, [meteringTokens, currentThreadUsage]);
 
   const outputMeteringTokens = useMemo(() => {
     if (meteringTokens === null) return null;
@@ -508,8 +474,6 @@ export const UsageCounter: React.FC<UsageCounterProps> = ({
               currentSessionTokens={currentSessionTokens}
               compressionStrength={compressionStrength}
               totalCoins={totalCoins}
-              cacheReadTokens={cacheReadTokens}
-              cacheWriteTokens={cacheWriteTokens}
             />
           )}
         </Card>


### PR DESCRIPTION
- MessageUsageInfo: show only coins, remove ctx display from inline view
- Add padding-right to message and reasoning content to prevent overlap
- UsageCounter: vertical layout with coins+ctx on first line, I/O on second
- Remove cache read/write from main display (still in hover card)