### PR TITLE
feat(chat): add message queue for sending during streaming

### DIFF
--- a/refact-agent/gui/src/__fixtures__/chat_config_thread.ts
+++ b/refact-agent/gui/src/__fixtures__/chat_config_thread.ts
@@ -493,4 +493,5 @@ export const CHAT_CONFIG_THREAD: Chat = {
   system_prompt: {},
   tool_use: "agent",
   send_immediately: false,
+  queued_messages: [],
 };

--- a/refact-agent/gui/src/components/Buttons/SendButton.tsx
+++ b/refact-agent/gui/src/components/Buttons/SendButton.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { DropdownMenu, IconButton, Flex, Badge } from "@radix-ui/themes";
+import {
+  PaperPlaneIcon,
+  CaretDownIcon,
+  ClockIcon,
+  LightningBoltIcon,
+} from "@radix-ui/react-icons";
+
+type SendButtonProps = {
+  disabled?: boolean;
+  isStreaming?: boolean;
+  queuedCount?: number;
+  onSend: () => void;
+  onSendImmediately: () => void;
+};
+
+export const SendButtonWithDropdown: React.FC<SendButtonProps> = ({
+  disabled,
+  isStreaming,
+  queuedCount = 0,
+  onSend,
+  onSendImmediately,
+}) => {
+  const showDropdown = isStreaming && !disabled;
+
+  if (!showDropdown) {
+    return (
+      <Flex align="center" gap="2">
+        {queuedCount > 0 && (
+          <Badge
+            color="amber"
+            size="1"
+            variant="soft"
+            title={`${queuedCount} message(s) queued`}
+          >
+            <ClockIcon width={12} height={12} />
+            {queuedCount}
+          </Badge>
+        )}
+        <IconButton
+          variant="ghost"
+          disabled={disabled}
+          title="Send message"
+          size="1"
+          type="submit"
+          onClick={(e) => {
+            e.preventDefault();
+            onSend();
+          }}
+        >
+          <PaperPlaneIcon />
+        </IconButton>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex align="center" gap="2">
+      {queuedCount > 0 && (
+        <Badge
+          color="amber"
+          size="1"
+          variant="soft"
+          title={`${queuedCount} message(s) queued`}
+        >
+          <ClockIcon width={12} height={12} />
+          {queuedCount}
+        </Badge>
+      )}
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <IconButton
+            variant="ghost"
+            disabled={disabled}
+            title="Send options"
+            size="1"
+          >
+            <PaperPlaneIcon />
+            <CaretDownIcon width={12} height={12} />
+          </IconButton>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Content size="1" align="end">
+          <DropdownMenu.Item onSelect={() => onSend()}>
+            <ClockIcon width={14} height={14} />
+            Queue message
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => onSendImmediately()}>
+            <LightningBoltIcon width={14} height={14} />
+            Send next
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </Flex>
+  );
+};
+
+export default SendButtonWithDropdown;

--- a/refact-agent/gui/src/components/Buttons/index.tsx
+++ b/refact-agent/gui/src/components/Buttons/index.tsx
@@ -11,3 +11,4 @@ export {
 export { ThinkingButton } from "./ThinkingButton";
 export { ContextCapButton } from "./ContextCapButton";
 export { FadedButton } from "./FadedButton";
+export { SendButtonWithDropdown } from "./SendButton";

--- a/refact-agent/gui/src/components/Chat/Chat.stories.tsx
+++ b/refact-agent/gui/src/components/Chat/Chat.stories.tsx
@@ -53,6 +53,7 @@ const Template: React.FC<{
       cache: {},
       system_prompt: {},
       thread: threadData,
+      queued_messages: [],
     },
     config,
   });

--- a/refact-agent/gui/src/components/Chat/Chat.tsx
+++ b/refact-agent/gui/src/components/Chat/Chat.tsx
@@ -61,8 +61,8 @@ export const Chat: React.FC<ChatProps> = ({
   const onEnableSend = () => dispatch(enableSend({ id: chatId }));
 
   const handleSubmit = useCallback(
-    (value: string) => {
-      submit({ question: value });
+    (value: string, sendPolicy?: "immediate" | "after_flow") => {
+      submit({ question: value, sendPolicy });
       if (isViewingRawJSON) {
         setIsViewingRawJSON(false);
       }

--- a/refact-agent/gui/src/components/ChatContent/ChatContent.module.css
+++ b/refact-agent/gui/src/components/ChatContent/ChatContent.module.css
@@ -124,3 +124,29 @@
   margin-top: var(--space-1);
   box-sizing: border-box;
 }
+
+.queuedMessage {
+  --base-card-surface-box-shadow: 0 0 0 1px
+    color-mix(in oklab, var(--amber-a5), var(--amber-5) 25%);
+  background: var(--color-surface);
+  border-radius: var(--radius-2);
+  padding: var(--space-2) var(--space-3);
+  margin-left: auto;
+  max-width: 85%;
+  opacity: 0.8;
+}
+
+.queuedMessagePriority {
+  --base-card-surface-box-shadow: 0 0 0 1px
+    color-mix(in oklab, var(--blue-a5), var(--blue-5) 25%);
+}
+
+.queuedMessageText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/refact-agent/gui/src/components/ChatContent/ChatContent.stories.tsx
+++ b/refact-agent/gui/src/components/ChatContent/ChatContent.stories.tsx
@@ -58,6 +58,7 @@ const MockedStore: React.FC<{
       cache: {},
       system_prompt: {},
       thread: threadData,
+      queued_messages: [],
     },
   });
 

--- a/refact-agent/gui/src/components/ChatContent/ChatContent.tsx
+++ b/refact-agent/gui/src/components/ChatContent/ChatContent.tsx
@@ -22,6 +22,7 @@ import {
   selectIsStreaming,
   selectIsWaiting,
   selectMessages,
+  selectQueuedMessages,
   selectThread,
 } from "../../features/Chat/Thread/selectors";
 import { takeWhile } from "../../utils";
@@ -31,6 +32,7 @@ import { ChatLinks, UncommittedChangesWarning } from "../ChatLinks";
 import { telemetryApi } from "../../services/refact/telemetry";
 import { PlaceHolderText } from "./PlaceHolderText";
 import { UsageCounter } from "../UsageCounter";
+import { QueuedMessage } from "./QueuedMessage";
 import {
   getConfirmationPauseStatus,
   getPauseReasonsWithPauseStatus,
@@ -50,6 +52,7 @@ export const ChatContent: React.FC<ChatContentProps> = ({
   const dispatch = useAppDispatch();
   const pauseReasonsWithPause = useAppSelector(getPauseReasonsWithPauseStatus);
   const messages = useAppSelector(selectMessages);
+  const queuedMessages = useAppSelector(selectQueuedMessages);
   const isStreaming = useAppSelector(selectIsStreaming);
   const thread = useAppSelector(selectThread);
   const { shouldShow } = useUsageCounter();
@@ -121,6 +124,17 @@ export const ChatContent: React.FC<ChatContentProps> = ({
           </Container>
         )}
         {renderMessages(messages, onRetryWrapper, isWaiting)}
+        {queuedMessages.length > 0 && (
+          <Flex direction="column" gap="2" mt="2">
+            {queuedMessages.map((queuedMsg, index) => (
+              <QueuedMessage
+                key={queuedMsg.id}
+                queuedMessage={queuedMsg}
+                position={index + 1}
+              />
+            ))}
+          </Flex>
+        )}
         <Container>
           <UncommittedChangesWarning />
         </Container>

--- a/refact-agent/gui/src/components/ChatContent/QueuedMessage.tsx
+++ b/refact-agent/gui/src/components/ChatContent/QueuedMessage.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback } from "react";
+import { Flex, Text, IconButton, Card, Badge } from "@radix-ui/themes";
+import {
+  Cross1Icon,
+  ClockIcon,
+  LightningBoltIcon,
+} from "@radix-ui/react-icons";
+import { useAppDispatch } from "../../hooks";
+import { dequeueUserMessage, QueuedUserMessage } from "../../features/Chat";
+import styles from "./ChatContent.module.css";
+import classNames from "classnames";
+
+type QueuedMessageProps = {
+  queuedMessage: QueuedUserMessage;
+  position: number;
+};
+
+function getMessagePreview(message: QueuedUserMessage["message"]): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  // Handle multimodal content
+  const textPart = message.content.find(
+    (part) => "type" in part && part.type === "text",
+  );
+  if (textPart && "text" in textPart) {
+    return textPart.text;
+  }
+  return "[Image attachment]";
+}
+
+export const QueuedMessage: React.FC<QueuedMessageProps> = ({
+  queuedMessage,
+  position,
+}) => {
+  const dispatch = useAppDispatch();
+  const isPriority = queuedMessage.priority;
+
+  const handleCancel = useCallback(() => {
+    dispatch(dequeueUserMessage({ queuedId: queuedMessage.id }));
+  }, [dispatch, queuedMessage.id]);
+
+  const preview = getMessagePreview(queuedMessage.message);
+
+  return (
+    <Card
+      className={classNames(styles.queuedMessage, {
+        [styles.queuedMessagePriority]: isPriority,
+      })}
+    >
+      <Flex gap="2" align="start" justify="between">
+        <Flex gap="2" align="center" style={{ flex: 1, minWidth: 0 }}>
+          <Badge color={isPriority ? "blue" : "amber"} variant="soft" size="1">
+            {isPriority ? (
+              <LightningBoltIcon width={12} height={12} />
+            ) : (
+              <ClockIcon width={12} height={12} />
+            )}
+            {position}
+          </Badge>
+          <Text
+            size="2"
+            color="gray"
+            className={styles.queuedMessageText}
+            title={preview}
+          >
+            {preview}
+          </Text>
+        </Flex>
+        <IconButton
+          size="1"
+          variant="ghost"
+          color="gray"
+          onClick={handleCancel}
+          title="Cancel queued message"
+        >
+          <Cross1Icon width={14} height={14} />
+        </IconButton>
+      </Flex>
+    </Card>
+  );
+};
+
+export default QueuedMessage;

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.test.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.test.tsx
@@ -102,7 +102,7 @@ describe("ChatForm", () => {
     await user.keyboard("{Enter}");
     const markdown = "```python\nprint(1)\n```\n";
     const expected = `${markdown}\n@file foo.txt:3\nfoo\n`;
-    expect(fakeOnSubmit).toHaveBeenCalledWith(expected);
+    expect(fakeOnSubmit).toHaveBeenCalledWith(expected, "after_flow");
   });
 
   test.each([

--- a/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
+++ b/refact-agent/gui/src/components/ChatForm/ChatForm.tsx
@@ -4,11 +4,11 @@ import { Flex, Card, Text, IconButton } from "@radix-ui/themes";
 import styles from "./ChatForm.module.css";
 
 import {
-  PaperPlaneButton,
   BackToSideBarButton,
   AgentIntegrationsButton,
   ThinkingButton,
   ContextCapButton,
+  SendButtonWithDropdown,
 } from "../Buttons";
 import { TextArea } from "../TextArea";
 import { Form } from "./Form";
@@ -56,6 +56,7 @@ import {
   selectIsWaiting,
   selectLastSentCompression,
   selectMessages,
+  selectQueuedMessages,
   selectThreadToolUse,
   selectToolUse,
 } from "../../features/Chat";
@@ -66,8 +67,10 @@ import { TokensPreview } from "./TokensPreview";
 import classNames from "classnames";
 import { ArchiveIcon } from "@radix-ui/react-icons";
 
+export type SendPolicy = "immediate" | "after_flow";
+
 export type ChatFormProps = {
-  onSubmit: (str: string) => void;
+  onSubmit: (str: string, sendPolicy?: SendPolicy) => void;
   onClose?: () => void;
   className?: string;
   unCalledTools: boolean;
@@ -97,6 +100,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const threadToolUse = useAppSelector(selectThreadToolUse);
   const messages = useAppSelector(selectMessages);
   const lastSentCompression = useAppSelector(selectLastSentCompression);
+  const queuedMessages = useAppSelector(selectQueuedMessages);
   const { compressChat, compressChatRequest, isCompressing } =
     useCompressChat();
   const autoFocus = useAutoFocusOnce();
@@ -183,33 +187,44 @@ export const ChatForm: React.FC<ChatFormProps> = ({
 
   const refs = useTourRefs();
 
-  const handleSubmit = useCallback(() => {
-    const trimmedValue = value.trim();
-    if (!disableSend && trimmedValue.length > 0) {
-      const valueWithFiles = attachedFiles.addFilesToInput(trimmedValue);
-      const valueIncludingChecks = addCheckboxValuesToInput(
-        valueWithFiles,
-        checkboxes,
-      );
-      // TODO: add @files
-      setLineSelectionInteracted(false);
-      onSubmit(valueIncludingChecks);
-      setValue(() => "");
-      unCheckAll();
-      attachedFiles.removeAll();
-    }
-  }, [
-    value,
-    disableSend,
-    attachedFiles,
-    checkboxes,
-    setLineSelectionInteracted,
-    onSubmit,
-    setValue,
-    unCheckAll,
-  ]);
+  const handleSubmit = useCallback(
+    (sendPolicy: SendPolicy = "after_flow") => {
+      const trimmedValue = value.trim();
+      // Both options queue during streaming, so both should be allowed
+      const canSubmit = trimmedValue.length > 0 && isOnline && !allDisabled;
 
-  const handleEnter = useOnPressedEnter(handleSubmit);
+      if (canSubmit) {
+        const valueWithFiles = attachedFiles.addFilesToInput(trimmedValue);
+        const valueIncludingChecks = addCheckboxValuesToInput(
+          valueWithFiles,
+          checkboxes,
+        );
+        // TODO: add @files
+        setLineSelectionInteracted(false);
+        onSubmit(valueIncludingChecks, sendPolicy);
+        setValue(() => "");
+        unCheckAll();
+        attachedFiles.removeAll();
+      }
+    },
+    [
+      value,
+      allDisabled,
+      isOnline,
+      attachedFiles,
+      checkboxes,
+      setLineSelectionInteracted,
+      onSubmit,
+      setValue,
+      unCheckAll,
+    ],
+  );
+
+  const handleSendImmediately = useCallback(() => {
+    handleSubmit("immediate");
+  }, [handleSubmit]);
+
+  const handleEnter = useOnPressedEnter(() => handleSubmit("after_flow"));
 
   const handleHelpInfo = useCallback((info: React.ReactNode | null) => {
     setHelpInfo(info);
@@ -351,7 +366,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         <Form
           disabled={disableSend}
           className={classNames(styles.chatForm__form, className)}
-          onSubmit={handleSubmit}
+          onSubmit={() => handleSubmit("after_flow")}
         >
           <FilesPreview files={previewFiles} />
 
@@ -434,11 +449,14 @@ export const ChatForm: React.FC<ChatFormProps> = ({
                     <AttachImagesButton />
                   )}
                 {/* TODO: Reserved space for microphone button coming later on */}
-                <PaperPlaneButton
-                  disabled={disableSend}
-                  title="Send message"
-                  size="1"
-                  type="submit"
+                <SendButtonWithDropdown
+                  disabled={
+                    !isOnline || allDisabled || value.trim().length === 0
+                  }
+                  isStreaming={isStreaming || isWaiting}
+                  queuedCount={queuedMessages.length}
+                  onSend={() => handleSubmit("after_flow")}
+                  onSendImmediately={handleSendImmediately}
                 />
               </Flex>
             </Flex>

--- a/refact-agent/gui/src/components/UsageCounter/UsageCounter.stories.tsx
+++ b/refact-agent/gui/src/components/UsageCounter/UsageCounter.stories.tsx
@@ -45,6 +45,7 @@ const MockedStore: React.FC<{
       tool_use: "agent",
       system_prompt: {},
       cache: {},
+      queued_messages: [],
       thread: {
         id: "test",
         messages: [

--- a/refact-agent/gui/src/features/Chat/Thread/actions.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/actions.ts
@@ -146,6 +146,24 @@ export const setSendImmediately = createAction<boolean>(
   "chatThread/setSendImmediately",
 );
 
+export type EnqueueUserMessagePayload = {
+  id: string;
+  message: import("../../../services/refact/types").UserMessage;
+  createdAt: number;
+};
+
+export const enqueueUserMessage = createAction<
+  EnqueueUserMessagePayload & { priority?: boolean }
+>("chatThread/enqueueUserMessage");
+
+export const dequeueUserMessage = createAction<{ queuedId: string }>(
+  "chatThread/dequeueUserMessage",
+);
+
+export const clearQueuedMessages = createAction(
+  "chatThread/clearQueuedMessages",
+);
+
 export const setChatMode = createAction<LspChatMode>("chatThread/setChatMode");
 
 export const setIntegrationData = createAction<Partial<IntegrationMeta> | null>(

--- a/refact-agent/gui/src/features/Chat/Thread/selectors.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/selectors.ts
@@ -126,6 +126,19 @@ export const selectLastSentCompression = createSelector(
   },
 );
 
+export const selectQueuedMessages = (state: RootState) =>
+  state.chat.queued_messages;
+
+export const selectQueuedMessagesCount = createSelector(
+  selectQueuedMessages,
+  (queued) => queued.length,
+);
+
+export const selectHasQueuedMessages = createSelector(
+  selectQueuedMessages,
+  (queued) => queued.length > 0,
+);
+
 export const selectHasUncalledTools = createSelector(
   selectMessages,
   (messages) => {

--- a/refact-agent/gui/src/features/Chat/Thread/types.ts
+++ b/refact-agent/gui/src/features/Chat/Thread/types.ts
@@ -1,7 +1,14 @@
 import { Usage } from "../../../services/refact";
 import { SystemPrompts } from "../../../services/refact/prompts";
-import { ChatMessages } from "../../../services/refact/types";
+import { ChatMessages, UserMessage } from "../../../services/refact/types";
 import { parseOrElse } from "../../../utils/parseOrElse";
+
+export type QueuedUserMessage = {
+  id: string;
+  message: UserMessage;
+  createdAt: number;
+  priority?: boolean;
+};
 
 export type IntegrationMeta = {
   name?: string;
@@ -55,6 +62,7 @@ export type Chat = {
   follow_ups_enabled?: boolean;
   title_generation_enabled?: boolean;
   use_compression?: boolean;
+  queued_messages: QueuedUserMessage[];
 };
 
 export type PayloadWithId = { id: string };


### PR DESCRIPTION
- Add ability to queue messages while AI is streaming/processing
- Two queue modes:
  - 'Add to queue': sends after current flow completes (including tools)
  - 'Send next': priority queue, sends at next turn (interrupts tool flow)
- Show queued messages as bubbles in chat with position indicators
- Priority messages shown with blue styling, regular with amber
- Badge shows queued message count near send button
- Dropdown menu appears during streaming with queue options

Changes:
- Add QueuedUserMessage type with priority flag
- Add enqueue/dequeue actions and reducer logic
- Add queue selectors
- Modify useSendChatRequest to queue when busy
- Add useAutoSend queue flush logic with priority handling
- Create SendButtonWithDropdown component
- Create QueuedMessage bubble component
- Update ChatForm to support queue submission
- Update fixtures and tests